### PR TITLE
Allow disable global programs

### DIFF
--- a/db/sql/V1.48__add_disabled_for_global_programs_table.sql
+++ b/db/sql/V1.48__add_disabled_for_global_programs_table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE global_programs_metadata ADD COLUMN disabled boolean NOT NULL DEFAULT(false);

--- a/pkg/api/persistence.go
+++ b/pkg/api/persistence.go
@@ -88,6 +88,6 @@ type VulcanitoStore interface {
 	DeleteChecktypeSetting(checktypeSettingID string) error
 
 	FindGlobalProgramMetadata(programID string, teamID string) (*GlobalProgramsMetadata, error)
-	UpsertGlobalProgramMetadata(teamID, program string, defaultAutosend bool, defaultCron string, autosend *bool, cron *string) error
+	UpsertGlobalProgramMetadata(teamID, program string, defaultAutosend bool, defaultDisabled bool, defaultCron string, autosend *bool, disabled *bool, cron *string) error
 	DeleteProgramMetadata(program string) error
 }

--- a/pkg/api/program.go
+++ b/pkg/api/program.go
@@ -104,7 +104,7 @@ func (p Program) ToResponse() *ProgramResponse {
 		autosend = *p.Autosend
 	}
 
-	var disabled bool = false // Default value
+	var disabled bool
 	// Disabled should be never nil this is just to avoid panics if for whatever
 	// reason this precondition is not meet.
 	if p.Disabled != nil {
@@ -148,6 +148,7 @@ type GlobalProgramsMetadata struct {
 	TeamID    string `gorm:"primary_key"`
 	Program   string `gorm:"primary_key"`
 	Autosend  *bool
+	Disabled  *bool
 	Cron      string `gorm:"-" json:"cron"` // A program can have empty cron expression, e.g: a program to be run on demand.
 	CreatedAt *time.Time
 	UpdatedAt *time.Time

--- a/pkg/api/service/middleware/global/global.go
+++ b/pkg/api/service/middleware/global/global.go
@@ -38,7 +38,7 @@ type GlobalStore interface {
 // to store a retrive metadata about global entities.
 type MetadataStore interface {
 	FindGlobalProgramMetadata(programID string, teamID string) (*api.GlobalProgramsMetadata, error)
-	UpsertGlobalProgramMetadata(teamID, program string, defaultAutosend bool, defaultCron string, autosend *bool, cron *string) error
+	UpsertGlobalProgramMetadata(teamID, program string, defaultAutosend bool, defaultDisabled bool, defaultCron string, autosend *bool, disabled *bool, cron *string) error
 	DeleteProgramMetadata(program string) error
 }
 

--- a/pkg/api/service/middleware/global/programs.go
+++ b/pkg/api/service/middleware/global/programs.go
@@ -13,6 +13,11 @@ import (
 	global "github.com/adevinta/vulcan-api/pkg/api/store/global"
 )
 
+const (
+	defaultDisabledValue = false
+	defaultAutosendValue = false
+)
+
 func (e *globalEntities) CreateProgram(ctx context.Context, program api.Program, teamID string) (*api.Program, error) {
 	if _, ok := e.store.Programs()[program.ID]; ok {
 		return nil, errors.MethodNotAllowed(errEntityNotModifiable)
@@ -136,11 +141,11 @@ func (e *globalEntities) UpdateProgram(ctx context.Context, program api.Program,
 	if (program.Autosend == nil && program.Disabled == nil) || program.Name != "" {
 		return nil, errors.Validation("only autosend and disabled fields can be modified for a global program")
 	}
-	defaultAutosend := false
+	defaultAutosend := defaultAutosendValue
 	if gp.DefaultMetadata.Autosend != nil {
 		defaultAutosend = *gp.DefaultMetadata.Autosend
 	}
-	defaultDisabled := false
+	defaultDisabled := defaultDisabledValue
 	if gp.DefaultMetadata.Disabled != nil {
 		defaultDisabled = *gp.DefaultMetadata.Disabled
 	}
@@ -170,11 +175,11 @@ func (e *globalEntities) CreateSchedule(ctx context.Context, programID string, c
 	if err != nil {
 		return nil, err
 	}
-	defaultAutosend := false
+	defaultAutosend := defaultAutosendValue
 	if gp.DefaultMetadata.Autosend != nil {
 		defaultAutosend = *gp.DefaultMetadata.Autosend
 	}
-	defaultDisabled := false
+	defaultDisabled := defaultDisabledValue
 	if gp.DefaultMetadata.Disabled != nil {
 		defaultDisabled = *gp.DefaultMetadata.Disabled
 	}

--- a/pkg/api/service/middleware/global/programs.go
+++ b/pkg/api/service/middleware/global/programs.go
@@ -134,7 +134,7 @@ func (e *globalEntities) UpdateProgram(ctx context.Context, program api.Program,
 	}
 	// We allow to modify autosend and disabled flags.
 	if (program.Autosend == nil && program.Disabled == nil) || program.Name != "" {
-		return nil, errors.Validation("only autosend and disabled fields can be modified for global program")
+		return nil, errors.Validation("only autosend and disabled fields can be modified for a global program")
 	}
 	defaultAutosend := false
 	if gp.DefaultMetadata.Autosend != nil {

--- a/pkg/api/store/cdc/proxy.go
+++ b/pkg/api/store/cdc/proxy.go
@@ -379,8 +379,8 @@ func (b *BrokerProxy) DeleteChecktypeSetting(checktypeSettingID string) error {
 func (b *BrokerProxy) FindGlobalProgramMetadata(programID string, teamID string) (*api.GlobalProgramsMetadata, error) {
 	return b.store.FindGlobalProgramMetadata(programID, teamID)
 }
-func (b *BrokerProxy) UpsertGlobalProgramMetadata(teamID, program string, defaultAutosend bool, defaultCron string, autosend *bool, cron *string) error {
-	return b.store.UpsertGlobalProgramMetadata(teamID, program, defaultAutosend, defaultCron, autosend, cron)
+func (b *BrokerProxy) UpsertGlobalProgramMetadata(teamID, program string, defaultAutosend bool, defaultDisabled bool, defaultCron string, autosend *bool, disabled *bool, cron *string) error {
+	return b.store.UpsertGlobalProgramMetadata(teamID, program, defaultAutosend, defaultDisabled, defaultCron, autosend, disabled, cron)
 }
 func (b *BrokerProxy) DeleteProgramMetadata(program string) error {
 	return b.store.DeleteProgramMetadata(program)

--- a/pkg/api/store/global/global.go
+++ b/pkg/api/store/global/global.go
@@ -129,7 +129,6 @@ type Policy interface {
 type Program struct {
 	ID              string
 	Name            string
-	Disabled        *bool
 	Policies        []PolicyGroup
 	DefaultMetadata api.GlobalProgramsMetadata
 }

--- a/pkg/api/store/global/programs.go
+++ b/pkg/api/store/global/programs.go
@@ -18,9 +18,8 @@ var vTrue = true
 var (
 	// PeriodicFullScan represents the global program used for periodic full scans.
 	PeriodicFullScan = Program{
-		ID:       "periodic-full-scan",
-		Name:     "Periodic Scan",
-		Disabled: &vFalse,
+		ID:   "periodic-full-scan",
+		Name: "Periodic Scan",
 		Policies: []PolicyGroup{
 			PolicyGroup{
 				Group:  "default-global",
@@ -39,14 +38,16 @@ var (
 
 			// Autosend is set by default to false for this program.
 			Autosend: &vFalse,
+
+			// Disabled is set by default to false for this program.
+			Disabled: &vFalse,
 		},
 	}
 	// RedconScan represents the global program used for periodic scans
 	// of the Redcon discovered assets.
 	RedconScan = Program{
-		ID:       "redcon-scan",
-		Name:     "Redcon Scan",
-		Disabled: &vTrue,
+		ID:   "redcon-scan",
+		Name: "Redcon Scan",
 		Policies: []PolicyGroup{
 			PolicyGroup{
 				Group:  "redcon-global",
@@ -58,13 +59,18 @@ var (
 			// Standard crontab specs, e.g. "* * * * ?"
 			// Descriptors, e.g. "@midnight", "@every 1h30m"
 			Cron: "0 8 7 10 *", // Run the scan every October 7th at 8am UTC.
+
+			// Autosend is set by default to false for this program.
+			Autosend: &vFalse,
+
+			// Disabled is set by default to true for this program.
+			Disabled: &vTrue,
 		},
 	}
 	// WebScanning represents the global program used for web scans
 	WebScanning = Program{
-		ID:       "web-scanning",
-		Name:     "Web Scanning",
-		Disabled: &vFalse,
+		ID:   "web-scanning",
+		Name: "Web Scanning",
 		Policies: []PolicyGroup{
 			PolicyGroup{
 				Group:  "web-scanning-global",
@@ -79,6 +85,9 @@ var (
 
 			// Autosend is set by default to false for this program.
 			Autosend: &vFalse,
+
+			// Disabled is set by default to false for this program.
+			Disabled: &vFalse,
 		},
 	}
 )

--- a/pkg/api/store/gprograms.go
+++ b/pkg/api/store/gprograms.go
@@ -38,6 +38,17 @@ DO
 		}
 	}
 
+	if disabled != nil {
+		err = db.Conn.Exec(`INSERT INTO global_programs_metadata(team_id, program, autosend, disabled, cron) VALUES(?,?,?,?,?)
+ON CONFLICT ON CONSTRAINT global_programs_metadata_pkey
+DO
+ UPDATE
+	SET disabled=EXCLUDED.disabled`, teamID, program, paramAutosend, paramDisabled, paramCron).Error
+		if err != nil {
+			return err
+		}
+	}
+
 	if cron != nil {
 		err = db.Conn.Exec(`INSERT INTO global_programs_metadata(team_id, program, autosend, disabled, cron) VALUES(?,?,?,?,?)
 ON CONFLICT ON CONSTRAINT global_programs_metadata_pkey

--- a/pkg/api/store/gprograms.go
+++ b/pkg/api/store/gprograms.go
@@ -9,12 +9,17 @@ import (
 	"github.com/adevinta/vulcan-api/pkg/api"
 )
 
-func (db vulcanitoStore) UpsertGlobalProgramMetadata(teamID, program string, defaultAutosend bool, defaultCron string, autosend *bool, cron *string) error {
+func (db vulcanitoStore) UpsertGlobalProgramMetadata(teamID, program string, defaultAutosend bool, defaultDisabled bool, defaultCron string, autosend *bool, disabled *bool, cron *string) error {
 	var err error
 
 	paramAutosend := defaultAutosend
 	if autosend != nil {
 		paramAutosend = *autosend
+	}
+
+	paramDisabled := defaultDisabled
+	if disabled != nil {
+		paramDisabled = *disabled
 	}
 
 	paramCron := defaultCron
@@ -23,22 +28,22 @@ func (db vulcanitoStore) UpsertGlobalProgramMetadata(teamID, program string, def
 	}
 
 	if autosend != nil {
-		err = db.Conn.Exec(`INSERT INTO global_programs_metadata(team_id, program, autosend, cron) VALUES(?,?,?,?)
+		err = db.Conn.Exec(`INSERT INTO global_programs_metadata(team_id, program, autosend, disabled, cron) VALUES(?,?,?,?,?)
 ON CONFLICT ON CONSTRAINT global_programs_metadata_pkey
 DO
  UPDATE
-	SET autosend=EXCLUDED.autosend`, teamID, program, paramAutosend, paramCron).Error
+	SET autosend=EXCLUDED.autosend`, teamID, program, paramAutosend, paramDisabled, paramCron).Error
 		if err != nil {
 			return err
 		}
 	}
 
 	if cron != nil {
-		err = db.Conn.Exec(`INSERT INTO global_programs_metadata(team_id, program, autosend, cron) VALUES(?,?,?,?)
+		err = db.Conn.Exec(`INSERT INTO global_programs_metadata(team_id, program, autosend, disabled, cron) VALUES(?,?,?,?,?)
 ON CONFLICT ON CONSTRAINT global_programs_metadata_pkey
 DO
  UPDATE
-	SET cron=EXCLUDED.cron`, teamID, program, paramAutosend, paramCron).Error
+	SET cron=EXCLUDED.cron`, teamID, program, paramAutosend, paramDisabled, paramCron).Error
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR allows disable global programs by adding `disabled` flag to the `global_programs_metadata` table.
The implementation is exactly the same as the `autosend` flag.

Show program:
```
vulcan-api-cli -H $VULCAN_HOST --key $VULCAN_TOKEN show programs --team_id $VULCAN_TEAM_ID --program_id web-scanning | jq

{
  "id": "web-scanning",
  "name": "Web Scanning",
  "global": true,
  "schedule": {
    "cron": "0 8 15 * *"
  },
  "autosend": false,
  "disabled": false,
  "policy_groups": [
    {
      "group": {
        "id": "web-scanning-global",
        "name": "web-scanning-global",
        "description": "assets scanned by web scanners",
        "options": "",
        "assets_count": 1
      },
      "policy": {
        "id": "web-scanning-global",
        "name": "web-scanning-global",
        "description": "Default set of checktypes related with web scanning",
        "settings_count": 1
      }
    }
  ]
}
```

Update program:
```
vulcan-api-cli -H $VULCAN_HOST --key $VULCAN_TOKEN update programs --team_id $VULCAN_TEAM_ID --program_id web-scanning --payload '{"disabled":true}' | jq

{
  "id": "web-scanning",
  "name": "Web Scanning",
  "global": true,
  "schedule": {
    "cron": "0 8 15 * *"
  },
  "autosend": false,
  "disabled": true,
  "policy_groups": [
    {
      "group": {
        "id": "web-scanning-global",
        "name": "web-scanning-global",
        "description": "assets scanned by web scanners",
        "options": "",
        "assets_count": 1
      },
      "policy": {
        "id": "web-scanning-global",
        "name": "web-scanning-global",
        "description": "Default set of checktypes related with web scanning",
        "settings_count": 1
      }
    }
  ]
}
```

global_programs_metadata table:
```
vulcanapi=> select program,autosend,cron,disabled from global_programs_metadata where program='web-scanning';
   program    | autosend |    cron    | disabled
--------------+----------+------------+----------
 web-scanning | f        | 0 8 15 * * | t
(1 row)
```