### PR TITLE
Modify Find Findings endpoint to comply with swagger definition

### DIFF
--- a/pkg/api/endpoint/findings.go
+++ b/pkg/api/endpoint/findings.go
@@ -219,7 +219,7 @@ func makeFindFindingEndpoint(s api.VulcanitoService, logger kitlog.Logger) endpo
 		}
 
 		if authorizedFindFindingRequest(finding.Finding.Target.Tags, team.Tag) {
-			return Ok{finding}, nil
+			return Ok{finding.Finding}, nil
 		}
 
 		return Forbidden{nil}, nil


### PR DESCRIPTION
The "Find Findings" endpoint was returning a response like the one
below, wrapping the finding object under a field named "finding":
```
{
  "finding": {
    "id": "...",
    "issue": {...},
    "target": {...},
  }
}
```

This does not match with what was defined in the API specification.
The correct thing to do is to return directly the finding directly as the root object:
```
{
  "id": "...",
  "issue": {...},
  "target": {...},
}
```