### PR TITLE
Redcon/scan program

### DIFF
--- a/pkg/api/store/global/programs.go
+++ b/pkg/api/store/global/programs.go
@@ -58,7 +58,7 @@ var (
 			// Minute | Hour | Dom | Month | Dow
 			// Standard crontab specs, e.g. "* * * * ?"
 			// Descriptors, e.g. "@midnight", "@every 1h30m"
-			Cron: "0 12 * * 2", // Run the scan every October 7th at 8am UTC.
+			Cron: "0 12 * * 2", // Run the scan every Tuesday at 12pm UTC.
 
 			// Autosend is set by default to false for this program.
 			Autosend: &vFalse,

--- a/pkg/api/store/global/programs.go
+++ b/pkg/api/store/global/programs.go
@@ -58,7 +58,7 @@ var (
 			// Minute | Hour | Dom | Month | Dow
 			// Standard crontab specs, e.g. "* * * * ?"
 			// Descriptors, e.g. "@midnight", "@every 1h30m"
-			Cron: "0 8 7 10 *", // Run the scan every October 7th at 8am UTC.
+			Cron: "0 12 * * 2", // Run the scan every October 7th at 8am UTC.
 
 			// Autosend is set by default to false for this program.
 			Autosend: &vFalse,

--- a/pkg/api/store/global/programs.go
+++ b/pkg/api/store/global/programs.go
@@ -51,7 +51,7 @@ var (
 		Policies: []PolicyGroup{
 			PolicyGroup{
 				Group:  "redcon-global",
-				Policy: "default-global",
+				Policy: "redcon-global",
 			},
 		},
 		DefaultMetadata: api.GlobalProgramsMetadata{


### PR DESCRIPTION
Summary of changes:
- Create a new Policy dedicated for **Redcon**. The policy inherits all checks from the Default-policy, but excludes `vulcan-nessus` from the list (4a37322)
- Change the existing `RedconScan` program to use the new Redcon policy (37753d3)
- Schedule the `RedconScan` program to run every Tuesday at 12:00 (but kept disabled for the time being) (696b7f7)