### PR TITLE
Remove default size limit for CDC events processing per execution

### DIFF
--- a/pkg/api/store/cdc/db.go
+++ b/pkg/api/store/cdc/db.go
@@ -21,7 +21,7 @@ const (
 // perform CDC related operations synchronized
 // across different instances.
 type DB interface {
-	GetLog(nEntries uint) ([]Event, error)
+	GetLog() ([]Event, error)
 	FailedEvent(event Event) error
 	CleanEvent(event Event) error
 	CleanLog(nEntries uint) error
@@ -104,11 +104,11 @@ func NewPQDB(conStr, dbTable string) (*PQDB, error) {
 	}, nil
 }
 
-// GetLog retrieves the oldest nEntries from the outbox table.
-func (p *PQDB) GetLog(nEntries uint) ([]Event, error) {
+// GetLog retrieves the log entries from the outbox table ordered by creation time.
+func (p *PQDB) GetLog() ([]Event, error) {
 	query := fmt.Sprintf(`SELECT id, operation, version, data, retries
-		FROM %s ORDER BY created_at LIMIT $1`, p.dbTable)
-	res, err := p.db.Query(query, nEntries)
+		FROM %s ORDER BY created_at`, p.dbTable)
+	res, err := p.db.Query(query)
 	if err != nil {
 		return []Event{}, err
 	}

--- a/pkg/api/store/cdc/proxy.go
+++ b/pkg/api/store/cdc/proxy.go
@@ -18,8 +18,6 @@ import (
 const (
 	// default advisory lock ID so we can handle sync across instances.
 	defLockID uint32 = 1869877622
-	// default N changes to query for DB log.
-	defNChanges = 10
 	// CDCLogTag is a tag to use for logging.
 	CDCLogTag = "CDC"
 )
@@ -107,7 +105,7 @@ LOOP:
 		}
 
 		// Get log
-		log, err := b.db.GetLog(defNChanges)
+		log, err := b.db.GetLog()
 		if err != nil {
 			b.logErr(err)
 			b.db.ReleaseLock(lock) // nolint

--- a/pkg/api/store/cdc/proxy_test.go
+++ b/pkg/api/store/cdc/proxy_test.go
@@ -20,10 +20,7 @@ type mockDB struct {
 	logEntries []Event
 }
 
-func (m *mockDB) GetLog(nEntries uint) ([]Event, error) {
-	if int(nEntries) <= len(m.logEntries) {
-		return m.logEntries[:nEntries], nil
-	}
+func (m *mockDB) GetLog() ([]Event, error) {
 	return m.logEntries, nil
 }
 func (m *mockDB) FailedEvent(event Event) error {
@@ -121,6 +118,8 @@ func TestBrokerProxySync(t *testing.T) {
 		brokerProxy := NewBrokerProxy(&mockLogger{},
 			mockDB, mockStore, mockParser)
 
+		wantNParsed := uint(len(mockDB.logEntries))
+
 		// Verify that broker proxy is waiting for signal
 		wait()
 		if mockParser.totalParsed > 0 {
@@ -141,9 +140,9 @@ func TestBrokerProxySync(t *testing.T) {
 		// and starts processing entries
 		_ = brokerProxy.DeleteTeam("teamID")
 		wait()
-		if mockParser.totalParsed != defNChanges {
+		if mockParser.totalParsed != wantNParsed {
 			t.Fatalf("expected %d parsed entries, but got: %d",
-				defNChanges, mockParser.totalParsed)
+				wantNParsed, mockParser.totalParsed)
 		}
 
 	})


### PR DESCRIPTION
This PR removes the previous default limit (10) for number of CDC log events that could be processed by the background goroutine that handles distributed transactions.
Instead, each time the background goroutine is awaken it will try to process all events that are available, executing them sequentially and deleting them if successful.