### PR TITLE
Handle distributed CreateAsset transaction for Vulnerability DB

### DIFF
--- a/pkg/api/store/assets.go
+++ b/pkg/api/store/assets.go
@@ -184,6 +184,11 @@ func (db vulcanitoStore) createAsset(tx *gorm.DB, asset api.Asset) (*api.Asset, 
 		return nil, db.logError(errors.Database(res.Error))
 	}
 
+	err := db.pushToOutbox(tx, opCreateAsset, asset)
+	if err != nil {
+		return nil, err
+	}
+
 	return &asset, nil
 }
 
@@ -294,6 +299,7 @@ func (db vulcanitoStore) DeleteAsset(asset api.Asset) error {
 	}
 
 	if result.RowsAffected == 0 {
+		tx.Rollback()
 		return db.logError(errors.Delete("Asset was not deleted"))
 	}
 

--- a/pkg/api/store/assets.go
+++ b/pkg/api/store/assets.go
@@ -274,20 +274,22 @@ func (db vulcanitoStore) UpdateAsset(asset api.Asset) (*api.Asset, error) {
 	}
 
 	result := tx.Model(&asset).Where("team_id = ?", asset.TeamID).Update(asset)
-	if result.RowsAffected == 0 {
-		return nil, db.logError(errors.Update("Asset was not updated"))
-	}
 	if result.Error != nil {
 		tx.Rollback()
 		return nil, db.logError(errors.Update(result.Error))
+	}
+	if result.RowsAffected == 0 {
+		tx.Rollback()
+		return nil, db.logError(errors.Update("Asset was not updated"))
 	}
 
 	// If asset identifier is changed, we have to propagate the action
 	// to the vulnerability DB so ownership from previous identifier is
 	// removed for this team if necessary, and also the new one is created.
 	if findAsset.Identifier != asset.Identifier {
-		err := db.pushToOutbox(tx, opUpdateAsset, findAsset)
+		err := db.pushToOutbox(tx, opUpdateAsset, findAsset, asset)
 		if err != nil {
+			tx.Rollback()
 			return nil, err
 		}
 	}

--- a/pkg/api/store/assets.go
+++ b/pkg/api/store/assets.go
@@ -284,9 +284,9 @@ func (db vulcanitoStore) UpdateAsset(asset api.Asset) (*api.Asset, error) {
 
 	// If asset identifier is changed, we have to propagate the action
 	// to the vulnerability DB so ownership from previous identifier is
-	// removed for this team.
+	// removed for this team if necessary, and also the new one is created.
 	if findAsset.Identifier != asset.Identifier {
-		err := db.pushToOutbox(tx, opDeleteAsset, findAsset)
+		err := db.pushToOutbox(tx, opUpdateAsset, findAsset)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/api/store/cdc/dto.go
+++ b/pkg/api/store/cdc/dto.go
@@ -12,6 +12,12 @@ type OpDeleteTeamDTO struct {
 	Team api.Team `json:"team"`
 }
 
+// OpCreateAssetDTO represents the data to store
+// as part of CDC log for a CreateAsset operation.
+type OpCreateAssetDTO struct {
+	Asset api.Asset `json:"asset"`
+}
+
 // OpDeleteAssetDTO represents the data to store
 // as part of CDC log for a DeleteAsset operation.
 type OpDeleteAssetDTO struct {

--- a/pkg/api/store/cdc/dto.go
+++ b/pkg/api/store/cdc/dto.go
@@ -28,6 +28,16 @@ type OpDeleteAssetDTO struct {
 	DupAssets int `json:"duplicates"`
 }
 
+// OpUpdateAssetDTO represents the data to store
+// as part of CDC log for a UpdateAsset operation.
+type OpUpdateAssetDTO struct {
+	Asset api.Asset `json:"asset"`
+	// DupAssets is the number of assets
+	// which have the same identifier in
+	// the same team as Asset
+	DupAssets int `json:"duplicates"`
+}
+
 // OpDeleteAllAssetsDTO represents the data to store
 // as part of CDC log for a DeleteAllAssets operation.
 type OpDeleteAllAssetsDTO struct {

--- a/pkg/api/store/cdc/dto.go
+++ b/pkg/api/store/cdc/dto.go
@@ -31,10 +31,11 @@ type OpDeleteAssetDTO struct {
 // OpUpdateAssetDTO represents the data to store
 // as part of CDC log for a UpdateAsset operation.
 type OpUpdateAssetDTO struct {
-	Asset api.Asset `json:"asset"`
+	OldAsset api.Asset `json:"old_asset"`
+	NewAsset api.Asset `json:"new_asset"`
 	// DupAssets is the number of assets
-	// which have the same identifier in
-	// the same team as Asset
+	// which have the same identifier as
+	// OldAsset for the same team.
 	DupAssets int `json:"duplicates"`
 }
 

--- a/pkg/api/store/cdc/parser.go
+++ b/pkg/api/store/cdc/parser.go
@@ -120,7 +120,6 @@ func (p *VulnDBTxParser) processDeleteTeam(data []byte) error {
 
 func (p *VulnDBTxParser) processCreateAsset(data []byte) error {
 	var dto OpCreateAssetDTO
-	ctx := context.Background()
 
 	err := json.Unmarshal(data, &dto)
 	if err != nil {
@@ -132,7 +131,7 @@ func (p *VulnDBTxParser) processCreateAsset(data []byte) error {
 		Tags:       []string{dto.Asset.Team.Tag},
 	}
 
-	_, err = p.VulnDBClient.CreateTarget(ctx, payload)
+	_, err = p.VulnDBClient.CreateTarget(context.Background(), payload)
 	return err
 }
 

--- a/pkg/api/store/cdc/parser.go
+++ b/pkg/api/store/cdc/parser.go
@@ -210,7 +210,7 @@ func (p *VulnDBTxParser) processUpdateAsset(data []byte) error {
 
 	// Process asset deletion
 	delDTO := OpDeleteAssetDTO{
-		Asset:     dto.Asset,
+		Asset:     dto.OldAsset,
 		DupAssets: dto.DupAssets,
 	}
 	delJSON, err := json.Marshal(delDTO)
@@ -224,7 +224,7 @@ func (p *VulnDBTxParser) processUpdateAsset(data []byte) error {
 
 	// Process asset creation
 	createDTO := OpCreateAssetDTO{
-		Asset: dto.Asset,
+		Asset: dto.NewAsset,
 	}
 	createJSON, err := json.Marshal(createDTO)
 	if err != nil {

--- a/pkg/api/store/cdc/parser.go
+++ b/pkg/api/store/cdc/parser.go
@@ -20,6 +20,7 @@ import (
 const (
 	// supported operations
 	opDeleteTeam       = "DeleteTeam"
+	opCreateAsset      = "CreateAsset"
 	opDeleteAsset      = "DeleteAsset"
 	opDeleteAllAssets  = "DeleteAllAssets"
 	opFindingOverwrite = "FindingOverwrite"
@@ -69,6 +70,8 @@ func (p *VulnDBTxParser) Parse(log []Event) (nParsed uint) {
 		switch event.Action() {
 		case opDeleteTeam:
 			processFunc = p.processDeleteTeam
+		case opCreateAsset:
+			processFunc = p.processCreateAsset
 		case opDeleteAsset:
 			processFunc = p.processDeleteAsset
 		case opDeleteAllAssets:
@@ -113,6 +116,24 @@ func (p *VulnDBTxParser) processDeleteTeam(data []byte) error {
 		return err
 	}
 	return nil
+}
+
+func (p *VulnDBTxParser) processCreateAsset(data []byte) error {
+	var dto OpCreateAssetDTO
+	ctx := context.Background()
+
+	err := json.Unmarshal(data, &dto)
+	if err != nil {
+		return errInvalidData
+	}
+
+	payload := api.CreateTarget{
+		Identifier: dto.Asset.Identifier,
+		Tags:       []string{dto.Asset.Team.Tag},
+	}
+
+	_, err = p.VulnDBClient.CreateTarget(ctx, payload)
+	return err
 }
 
 func (p *VulnDBTxParser) processDeleteAsset(data []byte) error {

--- a/pkg/api/store/cdc/parser_test.go
+++ b/pkg/api/store/cdc/parser_test.go
@@ -18,6 +18,10 @@ import (
 	vulndb "github.com/adevinta/vulnerability-db-api/pkg/model"
 )
 
+const (
+	errTestSetup = "err setting up test"
+)
+
 var (
 	mockOpDeleteTeamData []byte
 	mockOpDeleteTeamDTO  = OpDeleteTeamDTO{
@@ -45,6 +49,25 @@ var (
 			Identifier: "example.com",
 			Team: &api.Team{
 				Tag: "mockDeleteAssetTag",
+			},
+		},
+		DupAssets: 0,
+	}
+
+	mockOpUpdateAssetData []byte
+	mockOpUpdateAssetDTO  = OpUpdateAssetDTO{
+		OldAsset: api.Asset{
+			ID:         "aO",
+			Identifier: "exampleNew.com",
+			Team: &api.Team{
+				Tag: "mockUpdateAssetTag",
+			},
+		},
+		NewAsset: api.Asset{
+			ID:         "aN",
+			Identifier: "exampleOld.com",
+			Team: &api.Team{
+				Tag: "mockUpdateAssetTag",
 			},
 		},
 		DupAssets: 0,
@@ -117,23 +140,27 @@ func init() {
 	var err error
 	mockOpDeleteTeamData, err = json.Marshal(mockOpDeleteTeamDTO)
 	if err != nil {
-		panic("Err setting up test")
+		panic(errTestSetup)
 	}
 	mockOpCreateAssetData, err = json.Marshal(mockOpCreateAssetDTO)
 	if err != nil {
-		panic("Err setting up test")
+		panic(errTestSetup)
 	}
 	mockOpDeleteAssetData, err = json.Marshal(mockOpDeleteAssetDTO)
 	if err != nil {
-		panic("Err setting up test")
+		panic(errTestSetup)
+	}
+	mockOpUpdateAssetData, err = json.Marshal(mockOpUpdateAssetDTO)
+	if err != nil {
+		panic(errTestSetup)
 	}
 	mockOpDeleteAllAssetsData, err = json.Marshal(mockOpDeleteAllAssetsDTO)
 	if err != nil {
-		panic("Err setting up test")
+		panic(errTestSetup)
 	}
 	mockOpFindingOverwriteData, err = json.Marshal(mockOpFindingOverwriteDTO)
 	if err != nil {
-		panic("Err setting up test")
+		panic(errTestSetup)
 	}
 }
 
@@ -160,6 +187,10 @@ func TestParse(t *testing.T) {
 				Outbox{
 					Operation: opDeleteAsset,
 					DTO:       mockOpDeleteAssetData,
+				},
+				Outbox{
+					Operation: opUpdateAsset,
+					DTO:       mockOpUpdateAssetData,
 				},
 				Outbox{
 					Operation: opDeleteAllAssets,
@@ -193,7 +224,7 @@ func TestParse(t *testing.T) {
 					return f, nil
 				},
 			},
-			wantNParsed: 5,
+			wantNParsed: 6,
 		},
 		{
 			name: "Should return err unsupported action",

--- a/pkg/api/store/cdc/proxy.go
+++ b/pkg/api/store/cdc/proxy.go
@@ -287,7 +287,9 @@ func (b *BrokerProxy) DeleteAllAssets(teamID string) error {
 	return err
 }
 func (b *BrokerProxy) UpdateAsset(asset api.Asset) (*api.Asset, error) {
-	return b.store.UpdateAsset(asset)
+	a, err := b.store.UpdateAsset(asset)
+	go b.awakeBroker()
+	return a, err
 }
 
 func (b *BrokerProxy) GetAssetType(assetTypeName string) (*api.AssetType, error) {

--- a/pkg/api/store/cdc/proxy.go
+++ b/pkg/api/store/cdc/proxy.go
@@ -266,10 +266,14 @@ func (b *BrokerProxy) FindAsset(teamID, assetID string) (*api.Asset, error) {
 	return b.store.FindAsset(teamID, assetID)
 }
 func (b *BrokerProxy) CreateAsset(asset api.Asset, groups []api.Group) (*api.Asset, error) {
-	return b.store.CreateAsset(asset, groups)
+	a, err := b.store.CreateAsset(asset, groups)
+	go b.awakeBroker()
+	return a, err
 }
 func (b *BrokerProxy) CreateAssets(assets []api.Asset, groups []api.Group) ([]api.Asset, error) {
-	return b.store.CreateAssets(assets, groups)
+	aa, err := b.store.CreateAssets(assets, groups)
+	go b.awakeBroker()
+	return aa, err
 }
 func (b *BrokerProxy) DeleteAsset(asset api.Asset) error {
 	err := b.store.DeleteAsset(asset)

--- a/pkg/api/store/outbox.go
+++ b/pkg/api/store/outbox.go
@@ -17,6 +17,7 @@ import (
 const (
 	// operations
 	opDeleteTeam       = "DeleteTeam"
+	opCreateAsset      = "CreateAsset"
 	opDeleteAsset      = "DeleteAsset"
 	opDeleteAllAssets  = "DeleteAllAssets"
 	opFindingOverwrite = "FindingOverwrite"
@@ -32,6 +33,8 @@ func (db vulcanitoStore) pushToOutbox(tx *gorm.DB, op string, data ...interface{
 	switch op {
 	case opDeleteTeam:
 		buildFunc = db.buildDeleteTeamDTO
+	case opCreateAsset:
+		buildFunc = db.buildCreateAssetDTO
 	case opDeleteAsset:
 		buildFunc = db.buildDeleteAssetDTO
 	case opDeleteAllAssets:
@@ -77,6 +80,24 @@ func (db vulcanitoStore) buildDeleteTeamDTO(tx *gorm.DB, data ...interface{}) (i
 	team.Groups = nil
 
 	return cdc.OpDeleteTeamDTO{Team: team}, nil
+}
+
+// buildCreateAssetDTO builds a CreateAsset action DTO for outbox.
+// Expected input:
+//	- api.Asset
+func (db vulcanitoStore) buildCreateAssetDTO(tx *gorm.DB, data ...interface{}) (interface{}, error) {
+	if len(data) != 1 {
+		return nil, errInvalidParams
+	}
+	asset, ok := data[0].(api.Asset)
+	if !ok || asset.Team == nil {
+		return nil, errInvalidParams
+	}
+
+	// Don't store unnecessary data
+	asset.AssetGroups = nil
+
+	return cdc.OpCreateAssetDTO{Asset: asset}, nil
 }
 
 // buildDeleteAssetDTO builds a DeleteAsset action DTO for outbox.

--- a/pkg/api/store/team_test.go
+++ b/pkg/api/store/team_test.go
@@ -418,7 +418,7 @@ func TestStoreDeleteTeam(t *testing.T) {
 						CreatedAt:   &expCreatedAt,
 						UpdatedAt:   &expUpdatedAt,
 					},
-				})
+				}, nil)
 			}
 		})
 	}

--- a/pkg/api/vulndb.go
+++ b/pkg/api/vulndb.go
@@ -58,6 +58,13 @@ type UpdateFinding struct {
 	Status *string `json:"status"`
 }
 
+// CreateTarget specifies the payload for the vulnerability DB
+// create target endpoint.
+type CreateTarget struct {
+	Identifier string   `json:"identifier"`
+	Tags       []string `json:"tags"`
+}
+
 // TargetsParams represents the group of parameters
 // that can be used to customize the call to retrieve
 // the list of targets.
@@ -65,6 +72,12 @@ type TargetsParams struct {
 	Tag             string
 	Identifier      string
 	IdentifierMatch bool
+}
+
+// Target represents the response data returned from the vulnerability DB
+// for the create target request.
+type Target struct {
+	Target vulndb.Target `json:"target"`
 }
 
 // TargetsList represents the response data returned

--- a/pkg/vulnerabilitydb/vulnerabilitydb.go
+++ b/pkg/vulnerabilitydb/vulnerabilitydb.go
@@ -69,6 +69,7 @@ type Client interface {
 	FindingsTargets(ctx context.Context, params api.FindingsParams, pagination api.Pagination) (*api.FindingsTargetsList, error)
 	FindingsByTarget(ctx context.Context, params api.FindingsParams, pagination api.Pagination) (*api.FindingsList, error)
 	Targets(ctx context.Context, params api.TargetsParams, pagination api.Pagination) (*api.TargetsList, error)
+	CreateTarget(ctx context.Context, payload api.CreateTarget) (*api.Target, error)
 	DeleteTargetTag(ctx context.Context, authTag, targetID, tag string) error
 	DeleteTag(ctx context.Context, authTag, tag string) error
 	StatsMTTR(ctx context.Context, params api.StatsParams) (*api.StatsMTTR, error)
@@ -226,6 +227,20 @@ func (c *client) Targets(ctx context.Context, params api.TargetsParams, paginati
 	var targetsList api.TargetsList
 	err = json.Unmarshal(resp, &targetsList)
 	return &targetsList, err
+}
+
+// CreateTarget requests the creation of the specified target and associated tags.
+func (c *client) CreateTarget(ctx context.Context, payload api.CreateTarget) (*api.Target, error) {
+	data, err := json.Marshal(&payload)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.performRequest(ctx, http.MethodPost, targetsPath, noAuth, nil, data)
+
+	var targetResponse api.Target
+	err = json.Unmarshal(resp, &targetResponse)
+	return &targetResponse, err
 }
 
 // DeleteTargetTag removes the given tag for the given target.

--- a/pkg/vulnerabilitydb/vulnerabilitydb.go
+++ b/pkg/vulnerabilitydb/vulnerabilitydb.go
@@ -24,7 +24,7 @@ const (
 	// FindingStatusOpen defines the open status of a finding in the vulnerabilitydb.
 	FindingStatusOpen = "OPEN"
 
-	//FindingStatusFixed defines the fixed status of finding in the vulnerabilitydb
+	//FindingStatusFixed defines the fixed status of finding in the vulnerabilitydb.
 	FindingStatusFixed = "FIXED"
 
 	findingsPath         = "/findings"
@@ -237,6 +237,9 @@ func (c *client) CreateTarget(ctx context.Context, payload api.CreateTarget) (*a
 	}
 
 	resp, err := c.performRequest(ctx, http.MethodPost, targetsPath, noAuth, nil, data)
+	if err != nil {
+		return nil, err
+	}
 
 	var targetResponse api.Target
 	err = json.Unmarshal(resp, &targetResponse)

--- a/pkg/vulnerabilitydb/vulnerabilitydb.go
+++ b/pkg/vulnerabilitydb/vulnerabilitydb.go
@@ -231,7 +231,7 @@ func (c *client) Targets(ctx context.Context, params api.TargetsParams, paginati
 
 // CreateTarget requests the creation of the specified target and associated tags.
 func (c *client) CreateTarget(ctx context.Context, payload api.CreateTarget) (*api.Target, error) {
-	data, err := json.Marshal(&payload)
+	data, err := json.Marshal(payload)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/vulnerabilitydb/vulnerabilitydb_test.go
+++ b/pkg/vulnerabilitydb/vulnerabilitydb_test.go
@@ -24,6 +24,14 @@ var (
 		Pagination: api.PaginationInfo{},
 	}
 
+	mockTarget = &api.Target{
+		Target: vulndb.Target{
+			ID:         "mockID",
+			Identifier: "mocktarget.com",
+			Tags:       []string{"mocktag"},
+		},
+	}
+
 	mockTargets = &api.TargetsList{
 		Targets:    []vulndb.Target{},
 		Pagination: api.PaginationInfo{},
@@ -1251,6 +1259,192 @@ func TestTargets(t *testing.T) {
 		}
 		if err == nil && !reflect.DeepEqual(resp, mockTargets) {
 			t.Errorf("Expected response body as:\n%v\nBut got:\n%v", mockTargets, resp)
+		}
+
+		server.Close()
+	}
+}
+
+func TestCreateTarget(t *testing.T) {
+	type args struct {
+		ctx     context.Context
+		payload api.CreateTarget
+	}
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		args        args
+		srvErr      *srvErr
+		expectedErr error
+	}{
+		{
+			name: "Happy path",
+			args: args{
+				ctx: ctx,
+				payload: api.CreateTarget{
+					Identifier: "example.com",
+					Tags:       []string{"mytag"},
+				},
+			},
+			srvErr:      nil,
+			expectedErr: nil,
+		},
+		{
+			name: "Target with no tag",
+			args: args{
+				ctx: ctx,
+				payload: api.CreateTarget{
+					Identifier: "example.com",
+				},
+			},
+			srvErr:      nil,
+			expectedErr: nil,
+		},
+		{
+			name: "Should return 400 error from the vulnerability DB",
+			args: args{
+				ctx: ctx,
+				payload: api.CreateTarget{
+					Identifier: "example.com",
+					Tags:       []string{"tag"},
+				},
+			},
+			srvErr: &srvErr{
+				statusCode: http.StatusBadRequest,
+				mssg:       "400 Err",
+			},
+			expectedErr: errors.Assertion("400 Err"),
+		},
+		{
+			name: "Should return 401 error from the vulnerability DB",
+			args: args{
+				ctx: ctx,
+				payload: api.CreateTarget{
+					Identifier: "example.com",
+					Tags:       []string{"tag"},
+				},
+			},
+			srvErr: &srvErr{
+				statusCode: http.StatusUnauthorized,
+				mssg:       "401 Err",
+			},
+			expectedErr: errors.Unauthorized("401 Err"),
+		},
+		{
+			name: "Should return 403 error from the vulnerability DB",
+			args: args{
+				ctx: ctx,
+				payload: api.CreateTarget{
+					Identifier: "example.com",
+					Tags:       []string{"tag"},
+				},
+			},
+			srvErr: &srvErr{
+				statusCode: http.StatusForbidden,
+				mssg:       "403 Err",
+			},
+			expectedErr: errors.Forbidden("403 Err"),
+		},
+		{
+			name: "Should return 404 error from the vulnerability DB",
+			args: args{
+				ctx: ctx,
+				payload: api.CreateTarget{
+					Identifier: "example.com",
+					Tags:       []string{"tag"},
+				},
+			},
+			srvErr: &srvErr{
+				statusCode: http.StatusNotFound,
+				mssg:       "404 Err",
+			},
+			expectedErr: errors.NotFound("404 Err"),
+		},
+		{
+			name: "Should return 405 error from the vulnerability DB",
+			args: args{
+				ctx: ctx,
+				payload: api.CreateTarget{
+					Identifier: "example.com",
+					Tags:       []string{"tag"},
+				},
+			},
+			srvErr: &srvErr{
+				statusCode: http.StatusMethodNotAllowed,
+				mssg:       "405 Err",
+			},
+			expectedErr: errors.MethodNotAllowed("405 Err"),
+		},
+		{
+			name: "Should return 422 error from the vulnerability DB",
+			args: args{
+				ctx: ctx,
+				payload: api.CreateTarget{
+					Identifier: "example.com",
+					Tags:       []string{"tag"},
+				},
+			},
+			srvErr: &srvErr{
+				statusCode: http.StatusUnprocessableEntity,
+				mssg:       "422 Err",
+			},
+			expectedErr: errors.Validation("422 Err"),
+		},
+		{
+			name: "Should return 500 error from the vulnerability DB",
+			args: args{
+				ctx: ctx,
+				payload: api.CreateTarget{
+					Identifier: "example.com",
+					Tags:       []string{"tag"},
+				},
+			},
+			srvErr: &srvErr{
+				statusCode: http.StatusInternalServerError,
+				mssg:       "500 Err",
+			},
+			expectedErr: errors.Default("500 Err"),
+		},
+	}
+
+	for _, tt := range tests {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != targetsPath {
+				t.Fatalf("expected path to be /targets, but got: %s", r.URL.Path)
+			}
+			if r.Method != http.MethodPost {
+				t.Fatalf("expected http method to be POST, but got: %s", r.Method)
+			}
+
+			var httpStatus int
+			var resp []byte
+
+			if tt.srvErr != nil {
+				httpStatus = tt.srvErr.statusCode
+				resp = []byte(tt.srvErr.mssg)
+			} else {
+				httpStatus = http.StatusOK
+				resp, _ = json.Marshal(mockTarget)
+			}
+
+			w.WriteHeader(httpStatus)
+			w.Write(resp) // nolint
+		}))
+
+		client := NewClient(nil, server.URL, true)
+
+		resp, err := client.CreateTarget(tt.args.ctx, tt.args.payload)
+		if !reflect.DeepEqual(err, tt.expectedErr) {
+			if tt.expectedErr == nil {
+				t.Fatalf("No error expected, but got '%v'", err)
+			} else {
+				t.Fatalf("Expecting error '%v', but got '%v'", tt.expectedErr, err)
+			}
+		}
+		if err == nil && !reflect.DeepEqual(resp, mockTarget) {
+			t.Errorf("Expected response body as:\n%v\nBut got:\n%v", mockTarget, resp)
 		}
 
 		server.Close()


### PR DESCRIPTION
This PR adds modifications to Vulcan API in order to handle and trigger a distributed transaction for the VulnerabilityDB once a new asset is created in Vulcan. This, along with the transaction triggered from the operations that imply asset deletion, will make Vulcan API and VulnDB assets/targets data to be in sync.

Also adds handling of `UpdateAsset` operation which might trigger a deassociation for the tag-team in Vulnerability DB, as well as the creation of the new tag if the update operation includes an identifier modification.