### PR TITLE
Disable vulcan-retirejs check

### DIFF
--- a/pkg/api/store/global/policies.go
+++ b/pkg/api/store/global/policies.go
@@ -53,6 +53,7 @@ func (d *DefaultPolicy) Eval(ctx context.Context) ([]*api.ChecktypeSetting, erro
 		"vulcan-docker-image":         struct{}{},
 		"vulcan-zap":                  struct{}{},
 		"vulcan-seekret":              struct{}{},
+		"vulcan-retirejs":             struct{}{},
 	}
 
 	checkTypesInfo, err := d.checktypeInformer.ByAssettype(ctx)


### PR DESCRIPTION
This PR disables vulcan-retirejs check from _Default_, _Sensitive_ and _Redcon_ global policies.