### PR TITLE
Prevent escaperange gotcha

### DIFF
--- a/pkg/api/service/middleware/global/scans.go
+++ b/pkg/api/service/middleware/global/scans.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 
 	"github.com/adevinta/errors"
-	metrics "github.com/adevinta/vulcan-metrics-client"
 	"github.com/adevinta/vulcan-api/pkg/api"
 	"github.com/adevinta/vulcan-api/pkg/scanengine"
+	metrics "github.com/adevinta/vulcan-metrics-client"
 	scanengineApi "github.com/adevinta/vulcan-scan-engine/pkg/api"
 	scanengineData "github.com/adevinta/vulcan-scan-engine/pkg/api/endpoint"
 )
@@ -178,6 +178,7 @@ func (e *globalEntities) ListScans(ctx context.Context, teamID string, programID
 		return nil, err
 	}
 	for _, scan := range response.Scans {
+		scan := scan
 		s := e.buildScanWithProgram(&scan, program)
 		scans = append(scans, s)
 	}

--- a/pkg/api/service/scan.go
+++ b/pkg/api/service/scan.go
@@ -15,9 +15,9 @@ import (
 	"gopkg.in/go-playground/validator.v9"
 
 	"github.com/adevinta/errors"
-	metrics "github.com/adevinta/vulcan-metrics-client"
 	"github.com/adevinta/vulcan-api/pkg/api"
 	"github.com/adevinta/vulcan-api/pkg/scanengine"
+	metrics "github.com/adevinta/vulcan-metrics-client"
 	scanengineApi "github.com/adevinta/vulcan-scan-engine/pkg/api"
 	scanengineData "github.com/adevinta/vulcan-scan-engine/pkg/api/endpoint"
 )
@@ -37,6 +37,7 @@ func (s vulcanitoService) ListScans(ctx context.Context, teamID string, programI
 		return nil, err
 	}
 	for _, scanInfo := range response.Scans {
+		scanInfo := scanInfo
 		scan, err := s.fillScanInfo(ctx, &scanInfo, program, programID, teamID)
 		if err != nil {
 


### PR DESCRIPTION
This PR modifies the ListScans (both custom and global) method implementations to avoid the usage of pointers of range variables inside the for-loop, which may cause unintended behavior.