### PR TITLE
Disable vulcan-vulners checks in all the policies

### DIFF
--- a/pkg/api/store/global/policies.go
+++ b/pkg/api/store/global/policies.go
@@ -54,6 +54,7 @@ func (d *DefaultPolicy) Eval(ctx context.Context) ([]*api.ChecktypeSetting, erro
 		"vulcan-zap":                  struct{}{},
 		"vulcan-seekret":              struct{}{},
 		"vulcan-retirejs":             struct{}{},
+		"vulcan-vulners":              struct{}{},
 	}
 
 	checkTypesInfo, err := d.checktypeInformer.ByAssettype(ctx)


### PR DESCRIPTION
This PR disable the check vulcan-vulners in all the policies.