### PR TITLE
Disable "vulcan-tls" check

### DIFF
--- a/pkg/api/store/global/policies.go
+++ b/pkg/api/store/global/policies.go
@@ -55,6 +55,7 @@ func (d *DefaultPolicy) Eval(ctx context.Context) ([]*api.ChecktypeSetting, erro
 		"vulcan-seekret":              struct{}{},
 		"vulcan-retirejs":             struct{}{},
 		"vulcan-vulners":              struct{}{},
+		"vulcan-tls":                  struct{}{},
 	}
 
 	checkTypesInfo, err := d.checktypeInformer.ByAssettype(ctx)


### PR DESCRIPTION
Disable the "vulcan-tls" check due to [Mozilla's Cipherscan](https://github.com/mozilla/cipherscan) being unmaintained and [not supporting TLS 1.3](https://github.com/mozilla/cipherscan/pull/169). This causes the check to always report that TLS 1.3 is not supported by the servers regardless of whether or not that is actually the case. Insecure ciphers are already reported by the "vulcan-nessus" check as part of the SSL/TLS plugins (e.g. "[SSL Weak Cipher Suites Supported](https://www.tenable.com/plugins/nessus/26928)" or "[SSL/TLS Deprecated Ciphers Unsupported](https://www.tenable.com/plugins/nessus/132675)") in the [General family](https://www.tenable.com/plugins/nessus/families/General).