### PR TITLE
Whitelist ListFindingsLabels endpoint for users

### DIFF
--- a/cmd/vulcan-api/commands.go
+++ b/cmd/vulcan-api/commands.go
@@ -564,6 +564,7 @@ func addWhitelistingMiddleware(endpoints endpoint.Endpoints, logger log.Logger) 
 		endpoint.FindFinding:            true,
 		endpoint.CreateFindingOverwrite: true,
 		endpoint.ListFindingOverwrites:  true,
+		endpoint.ListFindingsLabels:     true,
 		// Metrics access.
 		endpoint.StatsMTTR:           true,
 		endpoint.StatsExposure:       true,


### PR DESCRIPTION
This PR fixes a bug where non-admin users could not access the live report because the request to the `[...]/findings/labels` endpoint was not whitelisted for unprivileged users. The request returned a 403 error, which triggered the session timeout message in the UI, prompting the users to reconnect indefinitely.