### PR TITLE
Create global program to scan CP discovered assets

### DIFF
--- a/pkg/api/assets_group.go
+++ b/pkg/api/assets_group.go
@@ -14,8 +14,11 @@ import (
 )
 
 const (
-	DiscoveredAssetsGroupName  = "security-team-discovered-assets"
-	WebScanningAssetsGroupName = "web-scanning"
+	// Assets discovered by Redcon.
+	DiscoveredAssetsGroupName = "security-team-discovered-assets"
+	// Assets discovered by the Common Platform.
+	CPDiscoveredAssetsGroupName = "cp-discovered-assets"
+	WebScanningAssetsGroupName  = "web-scanning"
 )
 
 type AssetGroup struct {

--- a/pkg/api/store/global/groups.go
+++ b/pkg/api/store/global/groups.go
@@ -33,8 +33,9 @@ func (d *DefaultGroup) Name() string {
 
 // Description returns a meanfull explanation of the group.
 func (d *DefaultGroup) Description() string {
-	return ` This global group contains all the assets that are in the default group of your team and not 
-	in the sensitive group. Assets in this group will be scanned using the default global policy`
+	return "This global group contains all the assets that are in the default " +
+		"group of your team and not in the sensitive group. Assets in this group " +
+		"will be scanned using the default global policy."
 }
 
 // Eval returns the current assets of a team belinging to this group.
@@ -126,7 +127,7 @@ func (d *SensitiveGroup) Name() string {
 }
 
 func (d *SensitiveGroup) Description() string {
-	return `assets in the sensitive group of the team`
+	return `Assets in the sensitive group of the team`
 }
 
 func (g *SensitiveGroup) ShadowTeamGroup() string {
@@ -240,9 +241,9 @@ func (g *CPGroup) Name() string {
 
 // Description returns a meaningful explanation of the group.
 func (g *CPGroup) Description() string {
-	return `This global group contains the Common Platform assets as discovered
-	by the CP, excluding those present in the Default, Sensitive or Redcon
-	groups.`
+	return "This global group contains the Common Platform assets as discovered " +
+		"by the CP, excluding those present in the Default, Sensitive or Redcon " +
+		"groups."
 }
 
 // Eval returns the current assets of a team belonging to this group.

--- a/pkg/api/store/global/groups.go
+++ b/pkg/api/store/global/groups.go
@@ -18,6 +18,7 @@ func init() {
 	registerGroup(&SensitiveGroup{&globalGroup{}})
 	registerGroup(&RedconGroup{&globalGroup{}})
 	registerGroup(&WebScanningGroup{&globalGroup{}})
+	registerGroup(&CPGroup{&globalGroup{}})
 }
 
 // DefaultGroup resolves all the assets present
@@ -224,4 +225,72 @@ func (g *WebScanningGroup) Eval(teamID string) ([]*api.Asset, error) {
 	var excluded []string
 
 	return g.Store.DisjoinAssetsInGroups(teamID, wsg.ID, excluded)
+}
+
+// CPGroup resolves the assets detected by CP excluding those present
+// in the Default, Sensitive and Redcon groups.
+type CPGroup struct {
+	*globalGroup
+}
+
+// Name returns the name of the group.
+func (g *CPGroup) Name() string {
+	return "cp-global"
+}
+
+// Description returns a meaningful explanation of the group.
+func (g *CPGroup) Description() string {
+	return `This global group contains the Common Platform assets as discovered
+	by the CP, excluding those present in the Default, Sensitive or Redcon
+	groups.`
+}
+
+// Eval returns the current assets of a team belonging to this group.
+func (g *CPGroup) Eval(teamID string) ([]*api.Asset, error) {
+	// Find the group id of the CP group of the team.
+	cpg, err := g.Store.FindGroupInfo(api.Group{
+		Name:   api.CPDiscoveredAssetsGroupName,
+		TeamID: teamID,
+	})
+	if err != nil {
+		if errors.IsRootOfKind(err, errors.ErrNotFound) {
+			return []*api.Asset{}, nil
+		}
+		return nil, err
+	}
+
+	var excluded []string
+
+	dg, err := g.Store.FindGroupInfo(api.Group{
+		Name:   "Default",
+		TeamID: teamID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("Default group not found: %w", err)
+	}
+	excluded = append(excluded, dg.ID)
+
+	sg, err := g.Store.FindGroupInfo(api.Group{
+		Name:   "Sensitive",
+		TeamID: teamID,
+	})
+	if err != nil && !errors.IsKind(err, errors.ErrNotFound) {
+		return nil, err
+	}
+	if err == nil {
+		excluded = append(excluded, sg.ID)
+	}
+
+	rg, err := g.Store.FindGroupInfo(api.Group{
+		Name:   api.DiscoveredAssetsGroupName,
+		TeamID: teamID,
+	})
+	if err != nil && !errors.IsKind(err, errors.ErrNotFound) {
+		return nil, err
+	}
+	if err == nil {
+		excluded = append(excluded, rg.ID)
+	}
+
+	return g.Store.DisjoinAssetsInGroups(teamID, cpg.ID, excluded)
 }

--- a/pkg/api/store/global/programs.go
+++ b/pkg/api/store/global/programs.go
@@ -10,6 +10,7 @@ func init() {
 	registerProgram(PeriodicFullScan)
 	registerProgram(RedconScan)
 	registerProgram(WebScanning)
+	registerProgram(CPScan)
 }
 
 var vFalse = false
@@ -87,6 +88,30 @@ var (
 			Autosend: &vFalse,
 
 			// Disabled is set by default to false for this program.
+			Disabled: &vFalse,
+		},
+	}
+	// CPScan represents the global program used for periodic scans
+	// of the Common Platform discovered assets.
+	CPScan = Program{
+		ID:   "cp-scan",
+		Name: "CP Scan",
+		Policies: []PolicyGroup{
+			PolicyGroup{
+				Group:  "cp-global",
+				Policy: "cp-global",
+			},
+		},
+		DefaultMetadata: api.GlobalProgramsMetadata{
+			// Minute | Hour | Dom | Month | Dow
+			// Standard crontab specs, e.g. "* * * * ?"
+			// Descriptors, e.g. "@midnight", "@every 1h30m"
+			Cron: "0 6 * * 3", // Run the scan every Wednesday at 6am UTC.
+
+			// Autosend is set by default to false for this program.
+			Autosend: &vFalse,
+
+			// Disabled is set by default to true for this program.
 			Disabled: &vFalse,
 		},
 	}


### PR DESCRIPTION
New global groups, policies and programs have been created in order to scan the assets discovered by the CP:
* The `cp-global` group contains all the assets present in its local group that are not present in the `Default`, `Sensitive` or the redcon local group. 
* The global policy is a copy of the redcon one.
* The global program has been scheduled to run every Wednesday at 6am UTC.

Tested in dev, contact me to show you.

_Note: I think it would be a big improvement to refactor the global entities to be defined in runtime using configuration files instead (e.g. YAML). Probably nobody else except us care about the Redcon or the CP global entities._