### PR TITLE
Bump docker file dependency versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: go
 dist: bionic
 env:
   global:
-    - FLYWAY_VERSION=8.0.2
+    - FLYWAY_VERSION=8.5.9
     - INPUT_BUILDARGS=FLYWAY_VERSION=$FLYWAY_VERSION
 go:
-  - 1.17.2
+  - 1.18.2
 services:
   - docker
 go_import_path: github.com/adevinta/vulcan-api

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright 2021 Adevinta
 
-FROM golang:1.17.2-alpine3.14 as builder
+FROM golang:1.18.2-alpine3.15 as builder
 
 WORKDIR /app
 
@@ -8,13 +8,13 @@ COPY . .
 
 RUN cd cmd/vulcan-api && GOOS=linux GOARCH=amd64 go build . && cd -
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 WORKDIR /flyway
 
 RUN apk add --no-cache --update openjdk8-jre-base bash gettext libc6-compat
 
-ARG FLYWAY_VERSION=8.0.2
+ARG FLYWAY_VERSION=8.5.9
 
 RUN wget https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/${FLYWAY_VERSION}/flyway-commandline-${FLYWAY_VERSION}.tar.gz \
     && tar -xzf flyway-commandline-${FLYWAY_VERSION}.tar.gz --strip 1 \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/adevinta/vulcan-api
 
-go 1.17
+go 1.18
 
 require (
 	github.com/adevinta/errors v0.0.0-20190715095242-ec69baa2d063


### PR DESCRIPTION
This PR bumps the version of the following dependencies:

- Flyway
- Alpine
- go version