### PR TITLE
Refactor annotations

### DIFF
--- a/pkg/api/endpoint/assets_test.go
+++ b/pkg/api/endpoint/assets_test.go
@@ -670,6 +670,47 @@ func TestMakeUpdateAssetsEndpoint(t *testing.T) {
 			wantErr:        nil,
 			wantClassified: true,
 		},
+
+		{
+			name: "ReturnAnnotations",
+			req: &AssetRequest{
+				ID:        "73e33dcb-d07c-41d1-bc32-80861b49941e",
+				TeamID:    "ea686be5-be9b-473b-ab1b-621a4f575d51",
+				Scannable: common.Bool(true),
+			},
+			want: Ok{
+				api.AssetResponse{
+					Identifier: "nonscannable.vulcan.example.com",
+					AssetType: api.AssetTypeResponse{
+						ID: "1937b564-bbc4-47f6-9722-b4a8c8ac0595",
+					},
+					Options:           common.String(`{}`),
+					Scannable:         common.Bool(true),
+					EnvironmentalCVSS: common.String("5"),
+					ROLFP:             api.DefaultROLFP,
+					Annotations: api.AssetAnnotationsMap{
+						"autodiscovery/security/keytodelete":    "valuetodelete",
+						"autodiscovery/security/keytonotupdate": "valuetonotupdate",
+						"autodiscovery/security/keytoupdate":    "valuetoupdate",
+						"keywithoutprefix":                      "valuewithoutprefix",
+					},
+					Groups: []*api.GroupResponse{
+						{
+							ID:          "1a893ae9-0340-48ff-a5ac-95408731c80b",
+							Name:        "security-discovered-assets",
+							AssetsCount: intPointer(2),
+						},
+						{
+							ID:          "dd4f7ee7-76de-4922-aeb3-1eade1233550",
+							Name:        "Default",
+							AssetsCount: intPointer(2),
+						},
+					},
+				},
+			},
+			wantErr:        nil,
+			wantClassified: false,
+		},
 	}
 
 	testTimeRef := time.Now()

--- a/pkg/api/persistence.go
+++ b/pkg/api/persistence.go
@@ -47,7 +47,7 @@ type VulcanitoStore interface {
 	ListAssets(teamID string, asset Asset) ([]*Asset, error)
 	FindAsset(teamID, assetID string) (*Asset, error)
 	CreateAsset(asset Asset, groups []Group) (*Asset, error)
-	CreateAssets(assets []Asset, groups []Group, annotations []*AssetAnnotation) ([]Asset, error)
+	CreateAssets(assets []Asset, groups []Group) ([]Asset, error)
 	DeleteAsset(asset Asset) error
 	DeleteAllAssets(teamID string) error
 	UpdateAsset(asset Asset) (*Asset, error)

--- a/pkg/api/service/assets.go
+++ b/pkg/api/service/assets.go
@@ -261,7 +261,7 @@ func (s vulcanitoService) CreateAssetsMultiStatus(ctx context.Context, assets []
 }
 
 // MergeDiscoveredAssets receives an list of assets to merge with the existing
-// assets of an auto-disvovery group for a team.
+// assets of an auto-discovery group for a team.
 func (s vulcanitoService) MergeDiscoveredAssets(ctx context.Context, teamID string, assets []api.Asset, groupName string) error {
 	// Check if the group exists and otherwise create it. Also check that there
 	// is no more than one match for the given group name.

--- a/pkg/api/service/assets.go
+++ b/pkg/api/service/assets.go
@@ -101,15 +101,15 @@ func (s vulcanitoService) CreateAssets(ctx context.Context, assets []api.Asset, 
 		}
 	}
 
-	// For all AWSAccount assets that do not specify an Alias, try to
-	// automatically fetch one
+	// Add Annotations and AWS Account alias (if needed).
 	for i, a := range assetsToCreate {
+		a.AssetAnnotations = annotations
 		if a.AssetType.Name == "AWSAccount" && a.Alias == "" {
 			a.Alias = s.getAccountName(a.Identifier)
-			assetsToCreate[i] = a
 		}
+		assetsToCreate[i] = a
 	}
-	return s.db.CreateAssets(assetsToCreate, groups, annotations)
+	return s.db.CreateAssets(assetsToCreate, groups)
 }
 
 func (s vulcanitoService) getAccountName(identifier string) string {

--- a/pkg/api/store/asset_annotations.go
+++ b/pkg/api/store/asset_annotations.go
@@ -69,9 +69,9 @@ func (db vulcanitoStore) UpdateAssetAnnotations(teamID string, assetID string, a
 	if tx.Commit().Error != nil {
 		return nil, db.logError(errors.Database(tx.Error))
 	}
-	// Notice that depending on the execution of other concurrent transactions
-	// we could be returning a set of annotations with information that were
-	// never present "as is" in the DB at any point in time.
+	// TODO: Depending on the execution of other concurrent transactions we
+	// could be returning a set of annotations with information that were never
+	// present "as is" in the DB at any point in time.
 	return annotations, nil
 }
 

--- a/pkg/api/store/asset_annotations.go
+++ b/pkg/api/store/asset_annotations.go
@@ -12,21 +12,11 @@ import (
 	"github.com/jinzhu/gorm"
 )
 
-// ListAssetAnnotations returns all annotations of a given asset id
+// ListAssetAnnotations returns all annotations of a given asset id.
 func (db vulcanitoStore) ListAssetAnnotations(teamID string, assetID string) ([]*api.AssetAnnotation, error) {
-	// Find asset
-	a := api.Asset{}
-	result := db.Conn.Where("team_id = ?", teamID).Where("id = ?", assetID).Find(&a)
-	if result.Error != nil {
-		if db.NotFoundError(result.Error) {
-			return nil, db.logError(errors.NotFound(result.Error))
-		}
-		return nil, db.logError(result.Error)
-	}
-
-	// List annotations
+	// List annotations.
 	annotations := []*api.AssetAnnotation{}
-	result = db.Conn.
+	result := db.Conn.
 		Preload("Asset").
 		Joins("left join assets on assets.id = asset_annotations.asset_id").
 		Where("asset_id = ?", assetID).
@@ -43,9 +33,9 @@ func (db vulcanitoStore) ListAssetAnnotations(teamID string, assetID string) ([]
 	return annotations, nil
 }
 
-// GetAssetAnnotation retrives a single Annotation by its key
+// GetAssetAnnotation retrives a single Annotation by its key.
 func (db vulcanitoStore) GetAssetAnnotation(teamID string, assetID string, key string) (*api.AssetAnnotation, error) {
-	// Create new annotations
+	// Create new annotations.
 	annotation := api.AssetAnnotation{}
 	result := db.Conn.
 		Preload("Asset").
@@ -69,16 +59,6 @@ func (db vulcanitoStore) GetAssetAnnotation(teamID string, assetID string, key s
 
 // CreateAssetAnnotations assign new annotations of a given asset id
 func (db vulcanitoStore) CreateAssetAnnotations(teamID string, assetID string, annotations []*api.AssetAnnotation) ([]*api.AssetAnnotation, error) {
-	// Find asset
-	a := api.Asset{}
-	result := db.Conn.Where("team_id = ?", teamID).Where("id = ?", assetID).Find(&a)
-	if result.Error != nil {
-		if db.NotFoundError(result.Error) {
-			return nil, db.logError(errors.NotFound(result.Error))
-		}
-		return nil, db.logError(result.Error)
-	}
-
 	// Start a new transaction
 	tx := db.Conn.Begin()
 	if tx.Error != nil {

--- a/pkg/api/store/asset_annotations.go
+++ b/pkg/api/store/asset_annotations.go
@@ -5,256 +5,121 @@ Copyright 2021 Adevinta
 package store
 
 import (
-	"fmt"
-
 	"github.com/adevinta/errors"
 	"github.com/adevinta/vulcan-api/pkg/api"
-	"github.com/jinzhu/gorm"
 )
 
 // ListAssetAnnotations returns all annotations of a given asset id.
 func (db vulcanitoStore) ListAssetAnnotations(teamID string, assetID string) ([]*api.AssetAnnotation, error) {
 	// List annotations.
-	annotations := []*api.AssetAnnotation{}
+	asset := api.Asset{}
 	result := db.Conn.
-		Preload("Asset").
-		Joins("left join assets on assets.id = asset_annotations.asset_id").
-		Where("asset_id = ?", assetID).
-		Where("team_id = ?", teamID).
-		Find(&annotations)
-
+		Preload("AssetAnnotations").
+		Where("team_id = ? and id = ?", teamID, assetID).
+		First(&asset)
 	if result.Error != nil {
 		if db.NotFoundError(result.Error) {
 			return nil, db.logError(errors.NotFound(result.Error))
 		}
 		return nil, db.logError(errors.Database(result.Error))
 	}
+	return asset.AssetAnnotations, nil
+}
 
+// CreateAssetAnnotations assign new annotations to a given asset belonging to
+// a given team.
+func (db vulcanitoStore) CreateAssetAnnotations(teamID string, assetID string, annotations []*api.AssetAnnotation) ([]*api.AssetAnnotation, error) {
+	tx := db.Conn.Begin()
+	if tx.Error != nil {
+		return nil, db.logError(errors.Database(tx.Error))
+	}
+	asset := api.Asset{
+		ID:               assetID,
+		TeamID:           teamID,
+		AssetAnnotations: annotations,
+	}
+	_, err := db.updateAssetTX(tx, asset, annotationsCreateBehavior)
+	if err != nil {
+		tx.Rollback()
+		return nil, err
+	}
+	if tx.Commit().Error != nil {
+		return nil, db.logError(errors.Database(tx.Error))
+	}
 	return annotations, nil
 }
 
-// GetAssetAnnotation retrives a single Annotation by its key.
-func (db vulcanitoStore) GetAssetAnnotation(teamID string, assetID string, key string) (*api.AssetAnnotation, error) {
-	// Create new annotations.
-	annotation := api.AssetAnnotation{}
-	result := db.Conn.
-		Preload("Asset").
-		Preload("Asset.Team").
-		Joins("left join assets on assets.id = asset_annotations.asset_id").
-		Joins("left join teams on teams.id = assets.team_id").
-		Where("teams.id = ?", teamID).
-		Where("asset_id = ?", assetID).
-		Where("key = ?", key).
-		First(&annotation)
-
-	if result.Error != nil {
-		if db.NotFoundError(result.Error) {
-			return nil, db.logError(errors.NotFound(result.Error))
-		}
-		return nil, db.logError(errors.Database(result.Error))
-	}
-
-	return &annotation, nil
-}
-
-// CreateAssetAnnotations assign new annotations of a given asset id
-func (db vulcanitoStore) CreateAssetAnnotations(teamID string, assetID string, annotations []*api.AssetAnnotation) ([]*api.AssetAnnotation, error) {
-	// Start a new transaction
-	tx := db.Conn.Begin()
-	if tx.Error != nil {
-		return nil, db.logError(errors.Database(tx.Error))
-	}
-
-	// Retrieve annotations for the asset
-	createdAnnotations := []*api.AssetAnnotation{}
-	for _, annotation := range annotations {
-		annotation := annotation
-
-		// Ensure consistent Asset ID
-		annotation.AssetID = assetID
-
-		// Check if annotation already exists. If yes, reject the whole
-		// request
-		_, err := db.GetAssetAnnotation(teamID, assetID, annotation.Key)
-		if err == nil {
-			tx.Rollback()
-			return nil, db.logError(errors.Create(fmt.Errorf("annotation '%v' already present for asset id '%v'", annotation.Key, annotation.AssetID)))
-		}
-		if err != nil && !errors.IsKind(err, errors.ErrNotFound) {
-			tx.Rollback()
-			return nil, err
-		}
-
-		// Create Annotation
-		result := tx.Create(&annotation)
-		if result.Error != nil {
-			tx.Rollback()
-			return nil, db.logError(errors.Create(result.Error))
-		}
-		createdAnnotations = append(createdAnnotations, annotation)
-	}
-
-	if tx.Commit().Error != nil {
-		return nil, db.logError(errors.Database(tx.Error))
-	}
-
-	return createdAnnotations, nil
-}
-
-// UpdateAssetAnnotations updates the value of existing annotations of a given
-// asset
+// UpdateAssetAnnotations updates the value of the existing annotations of a given
+// asset.
 func (db vulcanitoStore) UpdateAssetAnnotations(teamID string, assetID string, annotations []*api.AssetAnnotation) ([]*api.AssetAnnotation, error) {
-	// Find asset
-	a := api.Asset{}
-	result := db.Conn.Where("team_id = ?", teamID).Where("id = ?", assetID).Find(&a)
-	if result.Error != nil {
-		if db.NotFoundError(result.Error) {
-			return nil, db.logError(errors.NotFound(result.Error))
-		}
-		return nil, db.logError(result.Error)
-	}
-
-	// Start transaction
 	tx := db.Conn.Begin()
 	if tx.Error != nil {
 		return nil, db.logError(errors.Database(tx.Error))
 	}
-
-	updatedAnnotations := []*api.AssetAnnotation{}
-	for _, annotation := range annotations {
-		// Ensure consistent Asset ID
-		annotation.AssetID = assetID
-
-		// Ensure annotation already exists. If not, error out
-		an, err := db.GetAssetAnnotation(teamID, assetID, annotation.Key)
-		if err != nil {
-			tx.Rollback()
-			if errors.IsKind(err, errors.ErrNotFound) {
-				return nil, db.logError(errors.NotFound(fmt.Errorf("annotation '%v' not found for asset id '%v'", annotation.Key, annotation.AssetID)))
-			}
-			return nil, err
-		}
-		// Update Annotation
-		result := tx.Model(&an).Update(annotation)
-		if result.Error != nil {
-			tx.Rollback()
-			return nil, db.logError(errors.Update(result.Error))
-		}
-		if result.RowsAffected == 0 {
-			tx.Rollback()
-			return nil, db.logError(errors.Update("Asset Annotation was not updated"))
-		}
-
-		updatedAnnotations = append(updatedAnnotations, an)
+	asset := api.Asset{
+		ID:               assetID,
+		TeamID:           teamID,
+		AssetAnnotations: annotations,
 	}
-
+	_, err := db.updateAssetTX(tx, asset, annotationsUpdateBehavior)
+	if err != nil {
+		tx.Rollback()
+		return nil, err
+	}
 	if tx.Commit().Error != nil {
 		return nil, db.logError(errors.Database(tx.Error))
 	}
-
-	return updatedAnnotations, nil
+	// Notice that depending on the execution of other concurrent transactions
+	// we could be returning a set of annotations with information that were
+	// never present "as is" in the DB at any point in time.
+	return annotations, nil
 }
 
 // PutAssetAnnotations overrides all annotations of a given asset with new content.
 // Previous annotations will not ne preserved.
 func (db vulcanitoStore) PutAssetAnnotations(teamID string, assetID string, annotations []*api.AssetAnnotation) ([]*api.AssetAnnotation, error) {
-	// Start transaction
 	tx := db.Conn.Begin()
 	if tx.Error != nil {
 		return nil, db.logError(errors.Database(tx.Error))
 	}
-
-	newAnnotations, err := db.putAssetAnnotationsTX(tx, teamID, assetID, annotations)
+	asset := api.Asset{
+		ID:               assetID,
+		TeamID:           teamID,
+		AssetAnnotations: annotations,
+	}
+	_, err := db.updateAssetTX(tx, asset, annotationsReplaceBehavior)
 	if err != nil {
 		tx.Rollback()
 		return nil, err
 	}
-
 	if tx.Commit().Error != nil {
 		return nil, db.logError(errors.Database(tx.Error))
 	}
-
-	return newAnnotations, nil
+	// Notice that depending on the execution of other concurrent transactions
+	// we could be returning a set of annotations with information that were
+	// never present "as is" in the DB at any point time.
+	return annotations, nil
 }
 
-func (db vulcanitoStore) putAssetAnnotationsTX(tx *gorm.DB, teamID string, assetID string, annotations []*api.AssetAnnotation) ([]*api.AssetAnnotation, error) {
-	// Find asset
-	a := api.Asset{}
-	result := tx.Where("team_id = ?", teamID).Where("id = ?", assetID).Find(&a)
-	if result.Error != nil {
-		if db.NotFoundError(result.Error) {
-			return nil, db.logError(errors.NotFound(result.Error))
-		}
-		return nil, db.logError(result.Error)
-	}
-
-	// Clean up all annotations for given asset
-	result = tx.Delete(api.AssetAnnotation{}, "asset_id = ?", assetID)
-	if result.Error != nil {
-		return nil, db.logError(errors.Delete(result.Error))
-	}
-
-	newAnnotations := []*api.AssetAnnotation{}
-	for _, annotation := range annotations {
-		annotation := annotation
-
-		// Ensure consistent Asset ID
-		annotation.AssetID = assetID
-
-		// Create Annotation
-		result := tx.Create(&annotation)
-		if result.Error != nil {
-			return nil, db.logError(errors.Create(result.Error))
-		}
-		newAnnotations = append(newAnnotations, annotation)
-	}
-
-	return newAnnotations, nil
-}
-
-// DeleteAssetAnnotations deletes annotations "keys" from a given asset
+// DeleteAssetAnnotations deletes the given annotations belonging to the given
+// asset and team.
 func (db vulcanitoStore) DeleteAssetAnnotations(teamID string, assetID string, annotations []*api.AssetAnnotation) error {
-	// Find asset
-	a := api.Asset{}
-	result := db.Conn.Where("team_id = ?", teamID).Where("id = ?", assetID).Find(&a)
-	if result.Error != nil {
-		if db.NotFoundError(result.Error) {
-			return db.logError(errors.NotFound(result.Error))
-		}
-		return db.logError(result.Error)
-	}
-
-	// Start transaction
 	tx := db.Conn.Begin()
 	if tx.Error != nil {
 		return db.logError(errors.Database(tx.Error))
 	}
-
-	for _, annotation := range annotations {
-		// Ensure annotation already exists. If not, error out
-		an, err := db.GetAssetAnnotation(teamID, assetID, annotation.Key)
-		if err != nil {
-			tx.Rollback()
-			if errors.IsKind(err, errors.ErrNotFound) {
-				return db.logError(errors.NotFound(fmt.Errorf("annotation '%v' not found for asset id '%v'", annotation.Key, annotation.AssetID)))
-			}
-			return err
-		}
-		// Delete Annotation
-		result := tx.Model(&an).Delete(&an)
-		if result.Error != nil {
-			tx.Rollback()
-			return db.logError(errors.Update(result.Error))
-		}
-		if result.RowsAffected == 0 {
-			tx.Rollback()
-			return db.logError(errors.Update("Asset Annotation was not delete"))
-		}
+	asset := api.Asset{
+		ID:               assetID,
+		TeamID:           teamID,
+		AssetAnnotations: annotations,
 	}
-
+	_, err := db.updateAssetTX(tx, asset, annotationsDeleteBehavior)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
 	if tx.Commit().Error != nil {
 		return db.logError(errors.Database(tx.Error))
 	}
-
 	return nil
 }

--- a/pkg/api/store/asset_annotations_test.go
+++ b/pkg/api/store/asset_annotations_test.go
@@ -1,0 +1,275 @@
+/*
+Copyright 2022 Adevinta
+*/
+
+package store
+
+import (
+	"log"
+	"testing"
+
+	"github.com/adevinta/errors"
+	"github.com/adevinta/vulcan-api/pkg/api"
+	"github.com/adevinta/vulcan-api/pkg/testutil"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestStoreCreateAssetAnnotations(t *testing.T) {
+	db, err := testutil.PrepareDatabaseLocal("../../../testdata/fixtures", NewDB)
+	if err != nil {
+		log.Fatal(err)
+	}
+	tests := []struct {
+		name        string
+		teamID      string
+		assetID     string
+		annotations []*api.AssetAnnotation
+		want        []*api.AssetAnnotation
+		wantErr     error
+	}{
+		{
+			name:    "CreatesNonExistentAssetsAnnotations",
+			teamID:  "ea686be5-be9b-473b-ab1b-621a4f575d51",
+			assetID: "73e33dcb-d07c-41d1-bc32-80861b49941e",
+			annotations: []*api.AssetAnnotation{
+				{
+					Key:   "new",
+					Value: "value",
+				},
+			},
+			want: []*api.AssetAnnotation{
+				{
+					Key:   "new",
+					Value: "value",
+				},
+			},
+		},
+		{
+			name:    "DontCreateAnnotationsIfAlreadyExist",
+			teamID:  "ea686be5-be9b-473b-ab1b-621a4f575d51",
+			assetID: "73e33dcb-d07c-41d1-bc32-80861b49941e",
+			annotations: []*api.AssetAnnotation{
+				{
+					Key:   "autodiscovery/security/keytoupdate",
+					Value: "updated",
+				},
+			},
+			wantErr: errors.Create("annotation 'autodiscovery/security/keytoupdate' already present for asset id '73e33dcb-d07c-41d1-bc32-80861b49941e'"),
+		},
+		{
+			name:    "DontCreateAssetsAnnotationsForInvalidTeam",
+			teamID:  "a14c7c65-66ab-4676-bcf6-0dea9719f5c6",
+			assetID: "73e33dcb-d07c-41d1-bc32-80861b49941e",
+			annotations: []*api.AssetAnnotation{
+				{
+					Key:   "new",
+					Value: "value",
+				},
+			},
+			wantErr: errors.Forbidden("asset does not belong to team"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := db.CreateAssetAnnotations(tt.teamID, tt.assetID, tt.annotations)
+			if errToStr(err) != errToStr(tt.wantErr) {
+
+				t.Fatalf("got error != want err, %+v!=%+v", errToStr(err), errToStr(tt.wantErr))
+			}
+			diff := cmp.Diff(tt.want, got, cmp.Options{ignoreFieldsAnnotations})
+			if diff != "" {
+				t.Errorf("want annotations != got annotations, diff:\n %s", diff)
+			}
+		})
+	}
+}
+
+func TestStoreUpdateAssetAnnotations(t *testing.T) {
+	db, err := testutil.PrepareDatabaseLocal("../../../testdata/fixtures", NewDB)
+	if err != nil {
+		log.Fatal(err)
+	}
+	tests := []struct {
+		name        string
+		teamID      string
+		assetID     string
+		annotations []*api.AssetAnnotation
+		want        []*api.AssetAnnotation
+		wantErr     error
+	}{
+		{
+			name:    "DontUpdateAssetsAnnotationsForInvalidTeam",
+			teamID:  "a14c7c65-66ab-4676-bcf6-0dea9719f5c6",
+			assetID: "73e33dcb-d07c-41d1-bc32-80861b49941e",
+			annotations: []*api.AssetAnnotation{
+				{
+					Key:   "keywithoutprefix",
+					Value: "value",
+				},
+			},
+			wantErr: errors.Forbidden("asset does not belong to team"),
+		},
+		{
+			name:    "UpdatesExistentAssetsAnnotations",
+			teamID:  "ea686be5-be9b-473b-ab1b-621a4f575d51",
+			assetID: "73e33dcb-d07c-41d1-bc32-80861b49941e",
+			annotations: []*api.AssetAnnotation{
+				{
+					Key:   "autodiscovery/security/keytoupdate",
+					Value: "updatedvalue",
+				},
+			},
+			want: []*api.AssetAnnotation{
+				{
+					Key:   "autodiscovery/security/keytoupdate",
+					Value: "updatedvalue",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := db.UpdateAssetAnnotations(tt.teamID, tt.assetID, tt.annotations)
+			if errToStr(err) != errToStr(tt.wantErr) {
+				t.Fatalf("got error != want err, %+v!=%+v", errToStr(err), errToStr(tt.wantErr))
+			}
+			diff := cmp.Diff(tt.want, got, cmp.Options{ignoreFieldsAnnotations})
+			if diff != "" {
+				t.Errorf("want annotations != got annotations, diff:\n %s", diff)
+			}
+		})
+	}
+}
+
+func TestStorePutAssetAnnotations(t *testing.T) {
+	db, err := testutil.PrepareDatabaseLocal("../../../testdata/fixtures", NewDB)
+	if err != nil {
+		log.Fatal(err)
+	}
+	tests := []struct {
+		name        string
+		teamID      string
+		assetID     string
+		annotations []*api.AssetAnnotation
+		want        []*api.AssetAnnotation
+		wantErr     error
+	}{
+		{
+			name:    "DontPutAssetsAnnotationsForInvalidTeam",
+			teamID:  "a14c7c65-66ab-4676-bcf6-0dea9719f5c6",
+			assetID: "73e33dcb-d07c-41d1-bc32-80861b49941e",
+			annotations: []*api.AssetAnnotation{
+				{
+					Key:   "newkey",
+					Value: "newvalue",
+				},
+			},
+			wantErr: errors.Forbidden("asset does not belong to team"),
+		},
+		{
+			name:    "ReplaceExistentAssetsAnnotations",
+			teamID:  "ea686be5-be9b-473b-ab1b-621a4f575d51",
+			assetID: "73e33dcb-d07c-41d1-bc32-80861b49941e",
+			annotations: []*api.AssetAnnotation{
+				{
+					Key:   "newkey1",
+					Value: "newvalue1",
+				},
+				{
+					Key:   "newkey2",
+					Value: "newvalue2",
+				},
+			},
+			want: []*api.AssetAnnotation{
+				{
+					Key:   "newkey1",
+					Value: "newvalue1",
+				},
+				{
+					Key:   "newkey2",
+					Value: "newvalue2",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := db.PutAssetAnnotations(tt.teamID, tt.assetID, tt.annotations)
+			if errToStr(err) != errToStr(tt.wantErr) {
+				t.Fatalf("got error != want err, %+v!=%+v", errToStr(err), errToStr(tt.wantErr))
+			}
+			diff := cmp.Diff(tt.want, got, cmp.Options{ignoreFieldsAnnotations})
+			if diff != "" {
+				t.Errorf("want annotations != got annotations, diff:\n %s", diff)
+			}
+		})
+	}
+}
+
+func TestStoreDeleteAssetAnnotations(t *testing.T) {
+	db, err := testutil.PrepareDatabaseLocal("../../../testdata/fixtures", NewDB)
+	if err != nil {
+		log.Fatal(err)
+	}
+	tests := []struct {
+		name        string
+		teamID      string
+		assetID     string
+		annotations []*api.AssetAnnotation
+		want        []*api.AssetAnnotation
+		wantErr     error
+	}{
+		{
+			name:    "DontDeleteAssetsAnnotationsForInvalidTeam",
+			teamID:  "a14c7c65-66ab-4676-bcf6-0dea9719f5c6",
+			assetID: "73e33dcb-d07c-41d1-bc32-80861b49941e",
+			annotations: []*api.AssetAnnotation{
+				{
+					Key:   "newkey",
+					Value: "newvalue",
+				},
+			},
+			wantErr: errors.Forbidden("asset does not belong to team"),
+		},
+		{
+			name:    "DeleteAssetsAnnotations",
+			teamID:  "ea686be5-be9b-473b-ab1b-621a4f575d51",
+			assetID: "73e33dcb-d07c-41d1-bc32-80861b49941e",
+			annotations: []*api.AssetAnnotation{
+				{
+					Key: "autodiscovery/security/keytodelete",
+				},
+			},
+			want: []*api.AssetAnnotation{
+				{
+					Key:   "keywithoutprefix",
+					Value: "valuewithoutprefix",
+				},
+				{
+					Key:   "autodiscovery/security/keytoupdate",
+					Value: "valuetoupdate",
+				},
+				{
+					Key:   "autodiscovery/security/keytonotupdate",
+					Value: "valuetonotupdate",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := db.DeleteAssetAnnotations(tt.teamID, tt.assetID, tt.annotations)
+			if errToStr(err) != errToStr(tt.wantErr) {
+				t.Fatalf("got error != want err, %+v!=%+v", errToStr(err), errToStr(tt.wantErr))
+			}
+			got, err := db.ListAssetAnnotations(tt.teamID, tt.assetID)
+			if err != nil && !errors.IsKind(err, errors.ErrNotFound) {
+				t.Fatal(err)
+			}
+			diff := cmp.Diff(tt.want, got, cmp.Options{ignoreFieldsAnnotations})
+			if diff != "" {
+				t.Fatalf("want annotations != got annotations, diff:\n %s", diff)
+			}
+		})
+	}
+}

--- a/pkg/api/store/assets.go
+++ b/pkg/api/store/assets.go
@@ -205,7 +205,10 @@ func (db vulcanitoStore) createAsset(tx *gorm.DB, asset api.Asset) (*api.Asset, 
 		return nil, db.logError(errors.Create(res.Error))
 	}
 
-	res = tx.Preload("Team").Preload("AssetType").Find(&asset)
+	res = tx.
+		Preload("AssetAnnotations").
+		Preload("Team").
+		Preload("AssetType").Find(&asset)
 	if res.Error != nil {
 		return nil, db.logError(errors.Database(res.Error))
 	}

--- a/pkg/api/store/assets.go
+++ b/pkg/api/store/assets.go
@@ -314,10 +314,10 @@ func (db vulcanitoStore) UpdateAsset(asset api.Asset) (*api.Asset, error) {
 // updateAssetTX updates the non zero value fields of a given asset using the
 // given transaction including the annotations, that means that if the
 // AssetAnnotations field is not nil all the annotations of the asset not
-// present in the slice will be deleted. If the parameter onlyCreateAnnotations
-// is set to true the method will only try create new annotations without
-// deleting or updating the current annotations of the asset. Notice that at
-// least the values: ID and teamID of the asset must be specified.
+// present in the slice will be deleted. The annotations will be updated
+// according to to the value specified in the parameter annotationsBehavior.
+// Notice that at least the values: ID and teamID of the asset must be
+// specified.
 func (db vulcanitoStore) updateAssetTX(tx *gorm.DB, asset api.Asset, annotationsBehavior updateAnnotationsBehavior) (*api.Asset, error) {
 	findAsset := api.Asset{ID: asset.ID}
 	result := tx.

--- a/pkg/api/store/assets_test.go
+++ b/pkg/api/store/assets_test.go
@@ -160,12 +160,11 @@ func TestStoreCreateAssets(t *testing.T) {
 	}
 
 	tests := []struct {
-		name        string
-		assets      []api.Asset
-		groups      []api.Group
-		annotations []*api.AssetAnnotation
-		want        []api.Asset
-		wantErr     error
+		name    string
+		assets  []api.Asset
+		groups  []api.Group
+		want    []api.Asset
+		wantErr error
 	}{
 		{
 			name: "HappyPath",
@@ -195,6 +194,7 @@ func TestStoreCreateAssets(t *testing.T) {
 					Options:           common.String(`{"checktype_options":[{"name":"vulcan-exposed-memcheck","options":{"https":"true","port":"11211"}},{"name":"vulcan-nessus","options":{"enabled":"false"}}]}`),
 					ROLFP:             &api.ROLFP{IsEmpty: true},
 					Alias:             "Alias1",
+					AssetAnnotations:  []*api.AssetAnnotation{},
 				}},
 			wantErr: nil,
 		},
@@ -216,12 +216,6 @@ func TestStoreCreateAssets(t *testing.T) {
 		},
 		{
 			name: "WithAnnotations",
-			annotations: []*api.AssetAnnotation{
-				{
-					Key:   "key1",
-					Value: "value1",
-				},
-			},
 			assets: []api.Asset{
 				{
 					TeamID:            "a14c7c65-66ab-4676-bcf6-0dea9719f5c6",
@@ -231,7 +225,12 @@ func TestStoreCreateAssets(t *testing.T) {
 					Scannable:         common.Bool(true),
 					Options:           common.String(`{"checktype_options":[{"name":"vulcan-exposed-memcheck","options":{"https":"true","port":"11211"}},{"name":"vulcan-nessus","options":{"enabled":"false"}}]}`),
 					ROLFP:             &api.ROLFP{IsEmpty: true},
-					AssetAnnotations:  []*api.AssetAnnotation{},
+					AssetAnnotations: []*api.AssetAnnotation{
+						{
+							Key:   "key1",
+							Value: "value1",
+						},
+					},
 				}},
 			groups: []api.Group{},
 			want: []api.Asset{
@@ -256,7 +255,7 @@ func TestStoreCreateAssets(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := testStoreLocal.CreateAssets(tt.assets, tt.groups, tt.annotations)
+			got, err := testStoreLocal.CreateAssets(tt.assets, tt.groups)
 			if errToStr(err) != errToStr(tt.wantErr) {
 				t.Fatal(err)
 			}
@@ -319,6 +318,7 @@ func TestStoreCreateAsset(t *testing.T) {
 				Options:           common.String(opts),
 				ROLFP:             &api.ROLFP{IsEmpty: true},
 				Alias:             "Alias1",
+				AssetAnnotations:  []*api.AssetAnnotation{},
 			},
 			wantErr: nil,
 			expOutbox: expOutbox{
@@ -345,6 +345,7 @@ func TestStoreCreateAsset(t *testing.T) {
 						ROLFP:             &api.ROLFP{IsEmpty: true},
 						Scannable:         common.Bool(true),
 						Options:           common.String(opts),
+						AssetAnnotations:  []*api.AssetAnnotation{},
 					},
 				},
 			},

--- a/pkg/api/store/assets_test.go
+++ b/pkg/api/store/assets_test.go
@@ -522,24 +522,12 @@ func TestStoreUpdateAsset(t *testing.T) {
 				Identifier: "nonscannable.vulcan.example.com",
 				AssetAnnotations: []*api.AssetAnnotation{
 					{
-						Key:   "keywithoutprefix",
-						Value: "valuewithoutprefix",
-					},
-					{
-						Key:   "autodiscovery/security/keytoupdate",
-						Value: "updated",
-					},
-					{
 						Key:   "newkey",
 						Value: "newvalue",
 					},
 					{
-						Key:   "autodiscovery/security/keytonotupdate",
-						Value: "valuetonotupdate",
-					},
-					{
-						Key:   "autodiscovery/security/keytodelete",
-						Value: "valuetodelete",
+						Key:   "autodiscovery/security/keytoupdate",
+						Value: "updated",
 					},
 				},
 			},

--- a/pkg/api/store/assets_test.go
+++ b/pkg/api/store/assets_test.go
@@ -500,7 +500,7 @@ func TestStoreUpdateAsset(t *testing.T) {
 			},
 		},
 		{
-			name: "UpdatesButNotDeletesAnnotations",
+			name: "UpdatesAddsAndDeletesAnnotations",
 			asset: api.Asset{
 				ID:         "73e33dcb-d07c-41d1-bc32-80861b49941e",
 				Identifier: "nonscannable.vulcan.example.com",

--- a/pkg/api/store/cdc/proxy.go
+++ b/pkg/api/store/cdc/proxy.go
@@ -277,8 +277,8 @@ func (b *BrokerProxy) CreateAsset(asset api.Asset, groups []api.Group) (*api.Ass
 	go b.awakeBroker()
 	return a, err
 }
-func (b *BrokerProxy) CreateAssets(assets []api.Asset, groups []api.Group, annotations []*api.AssetAnnotation) ([]api.Asset, error) {
-	aa, err := b.store.CreateAssets(assets, groups, annotations)
+func (b *BrokerProxy) CreateAssets(assets []api.Asset, groups []api.Group) ([]api.Asset, error) {
+	aa, err := b.store.CreateAssets(assets, groups)
 	go b.awakeBroker()
 	return aa, err
 }

--- a/postman/vulcan.postman_collection.json
+++ b/postman/vulcan.postman_collection.json
@@ -1,8 +1,9 @@
 {
 	"info": {
-		"_postman_id": "10d226f7-bbcc-416e-9a91-5a7e4ce580cf",
+		"_postman_id": "e181bd07-6e5f-477e-99e1-d92334ad2f1f",
 		"name": "vulcan",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "6686087"
 	},
 	"item": [
 		{
@@ -1996,13 +1997,13 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"Status code is 404\", function () {",
-											"    pm.response.to.have.status(404);",
+											"pm.test(\"Status code is 403\", function () {",
+											"    pm.response.to.have.status(403);",
 											"});",
 											"",
-											"pm.test(\"Response is correct\", function () {",
+											"pm.test(\"Forbidden\", function () {",
 											"    var jsonData = pm.response.json();",
-											"    pm.expect(jsonData.type).to.eql(\"Record not found\")",
+											"    pm.expect(jsonData.type).to.eql(\"Forbidden\")",
 											"});"
 										],
 										"type": "text/javascript"
@@ -2046,13 +2047,13 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"Status code is 404\", function () {",
-											"    pm.response.to.have.status(404);",
+											"pm.test(\"Status code is 403\", function () {",
+											"    pm.response.to.have.status(403);",
 											"});",
 											"",
-											"pm.test(\"Response is correct\", function () {",
+											"pm.test(\"Forbidden\", function () {",
 											"    var jsonData = pm.response.json();",
-											"    pm.expect(jsonData.type).to.eql(\"Record not found\")",
+											"    pm.expect(jsonData.type).to.eql(\"Forbidden\")",
 											"});"
 										],
 										"type": "text/javascript"
@@ -2096,13 +2097,13 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"Status code is 404\", function () {",
-											"    pm.response.to.have.status(404);",
+											"pm.test(\"Status code is 403\", function () {",
+											"    pm.response.to.have.status(403);",
 											"});",
 											"",
-											"pm.test(\"Response is correct\", function () {",
+											"pm.test(\"Forbidden\", function () {",
 											"    var jsonData = pm.response.json();",
-											"    pm.expect(jsonData.type).to.eql(\"Record not found\")",
+											"    pm.expect(jsonData.type).to.eql(\"Forbidden\")",
 											"});"
 										],
 										"type": "text/javascript"


### PR DESCRIPTION
This PR refactors the the logic of the persistence layer handling the CRUD operations of the asset annotations. This refactor it's needed as a previous step to being able to implement CDC for the assets (including their annotations). The concrete modifications are:
- Now all the CRUD operations over assets (or asset annotations) end up calling the same methods, for creating, modifying or deleting assets.
- The logic for checking if the annotations of an asset belong to the authorized team of the user calling the endpoints of the asset annotations, are improved in order to avoid a race condition that could make the check to fail.
- Some test for the asset annotations storage layer have been added.
- Some comments about some posible concurrency problems when modifying assets were added, so we can address them in future PRs.