### PR TITLE
Assets cdc

### DIFF
--- a/pkg/api/store/asset_annotations_test.go
+++ b/pkg/api/store/asset_annotations_test.go
@@ -73,7 +73,6 @@ func TestStoreCreateAssetAnnotations(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := db.CreateAssetAnnotations(tt.teamID, tt.assetID, tt.annotations)
 			if errToStr(err) != errToStr(tt.wantErr) {
-
 				t.Fatalf("got error != want err, %+v!=%+v", errToStr(err), errToStr(tt.wantErr))
 			}
 			diff := cmp.Diff(tt.want, got, cmp.Options{ignoreFieldsAnnotations})

--- a/pkg/api/store/assets.go
+++ b/pkg/api/store/assets.go
@@ -363,12 +363,7 @@ func (db vulcanitoStore) updateAssetTX(tx *gorm.DB, asset api.Asset, annotations
 	// We assume the team information can be stale data.
 	asset.Team = &assetInfo.Team
 	if annotations != nil {
-		err = db.updateAnnotationsTX(tx, asset.ID, asset.TeamID, annotations, annotationsBehavior)
-		if err != nil {
-			return nil, err
-		}
-		stm = `SELECT key, value FROM asset_annotations WHERE asset_id = ?`
-		err = tx.Raw(stm, asset.ID).Scan(&annotations).Error
+		annotations, err = db.updateAnnotationsTX(tx, asset.ID, asset.TeamID, annotations, annotationsBehavior)
 		if err != nil {
 			return nil, err
 		}
@@ -1061,6 +1056,7 @@ func (db vulcanitoStore) createAnnotationsTX(tx *gorm.DB, assetID string, teamID
 			err = errors.Create(err)
 			return nil, db.logError(err)
 		}
+		a.AssetID = ""
 		if result.Error != nil {
 			return nil, db.logError(errors.Update(result.Error))
 		}
@@ -1087,7 +1083,7 @@ func (db vulcanitoStore) updateExistingAnnotationsTX(tx *gorm.DB, assetID string
 		}
 		out = append(out, &a)
 	}
-	return nil
+	return out, nil
 }
 
 func (db vulcanitoStore) deleteAnnotationsTX(tx *gorm.DB, assetID string, teamID string, annotations []*api.AssetAnnotation) error {

--- a/pkg/api/store/assets.go
+++ b/pkg/api/store/assets.go
@@ -519,7 +519,7 @@ func (db vulcanitoStore) pushDelAssetsToOutbox(tx *gorm.DB,
 
 		// The number of the asset types is low (less than 20) and it's
 		// expected to continue to be low, so we can consider this loop as fast
-		// as a lockup in a hashtable.
+		// as a lookup in a hashtable.
 		for _, at := range assetTypes {
 			if at.ID == asset.AssetTypeID {
 				at := at

--- a/pkg/api/store/cdc/dto.go
+++ b/pkg/api/store/cdc/dto.go
@@ -18,14 +18,16 @@ type OpCreateAssetDTO struct {
 	Asset api.Asset `json:"asset"`
 }
 
-// OpDeleteAssetDTO represents the data to store
-// as part of CDC log for a DeleteAsset operation.
+// OpDeleteAssetDTO represents the data to store as part of CDC log for a
+// DeleteAsset operation.
 type OpDeleteAssetDTO struct {
 	Asset api.Asset `json:"asset"`
-	// DupAssets is the number of assets
-	// which have the same identifier in
-	// the same team as Asset
+	// DupAssets is the number of assets which have the same identifier in the
+	// same team as Asset.
 	DupAssets int `json:"duplicates"`
+	// Marks the cause for the asset to be deleted an operation for deleteing
+	// all assets of a team.
+	DeleteAllAssetsOp bool `json:"delete_all_assets_op"`
 }
 
 // OpUpdateAssetDTO represents the data to store

--- a/pkg/api/store/cdc/dto.go
+++ b/pkg/api/store/cdc/dto.go
@@ -25,8 +25,8 @@ type OpDeleteAssetDTO struct {
 	// DupAssets is the number of assets which have the same identifier in the
 	// same team as Asset.
 	DupAssets int `json:"duplicates"`
-	// Marks the cause for the asset to be deleted an operation for deleteing
-	// all assets of a team.
+	// The operation the caused this asset to be deleted was a call to "delete
+	// all assets of a team".
 	DeleteAllAssetsOp bool `json:"delete_all_assets_op"`
 }
 

--- a/pkg/api/store/cdc/parser.go
+++ b/pkg/api/store/cdc/parser.go
@@ -152,7 +152,11 @@ func (p *AsyncTxParser) processDeleteAsset(data []byte) error {
 	if err != nil {
 		return errInvalidData
 	}
-
+	// By now, we don't process the assets deleted in a "delete all assets"
+	// operation.
+	if dto.DeleteAllAssetsOp {
+		return nil
+	}
 	if dto.DupAssets > 0 {
 		// If there are more assets with the same
 		// identifier and for the same team, do not

--- a/pkg/api/store/outbox.go
+++ b/pkg/api/store/outbox.go
@@ -131,6 +131,9 @@ func (db vulcanitoStore) buildDeleteAssetDTO(tx *gorm.DB, data ...interface{}) (
 	// Because multiple assets can have the same identifier, even
 	// for the same team, we have to count how many duplicates
 	// are for the given asset identifier and its associated team.
+	// TODO: Review this query could have problems if the assets of a team
+	// having the same identifier have change since the outbox operations was
+	// `enqueued'.
 	dupAssets, err := db.countTeamAssetsByIdentifier(asset.TeamID, asset.Identifier)
 	if err != nil {
 		return nil, err

--- a/pkg/api/store/outbox.go
+++ b/pkg/api/store/outbox.go
@@ -55,7 +55,9 @@ func (db vulcanitoStore) pushToOutbox(tx *gorm.DB, op string, data ...interface{
 	if err != nil {
 		return db.logError(errors.Default(err))
 	}
-
+	if dto == nil {
+		return nil
+	}
 	dtoData, err := json.Marshal(dto)
 	if err != nil {
 		return db.logError(errors.Default(err))
@@ -110,12 +112,20 @@ func (db vulcanitoStore) buildCreateAssetDTO(tx *gorm.DB, data ...interface{}) (
 // Expected input:
 //	- api.Asset
 func (db vulcanitoStore) buildDeleteAssetDTO(tx *gorm.DB, data ...interface{}) (interface{}, error) {
-	if len(data) != 1 {
+	if len(data) != 1 && len(data) != 2 {
 		return nil, errInvalidParams
 	}
 	asset, ok := data[0].(api.Asset)
 	if !ok || asset.Team == nil {
 		return nil, errInvalidParams
+	}
+	deleteAllAssetsOp := false
+	if len(data) == 2 {
+		param, ok := data[1].(bool)
+		if !ok {
+			return nil, errInvalidParams
+		}
+		deleteAllAssetsOp = param
 	}
 
 	// Because multiple assets can have the same identifier, even
@@ -131,7 +141,7 @@ func (db vulcanitoStore) buildDeleteAssetDTO(tx *gorm.DB, data ...interface{}) (
 	// Don't store unnecessary data
 	asset.AssetGroups = nil
 
-	return cdc.OpDeleteAssetDTO{Asset: asset, DupAssets: dupAssets}, nil
+	return cdc.OpDeleteAssetDTO{Asset: asset, DupAssets: dupAssets, DeleteAllAssetsOp: deleteAllAssetsOp}, nil
 }
 
 // buildUpdateAssetDTO builds a UpdateAsset action DTO for outbox.
@@ -183,21 +193,16 @@ func (db vulcanitoStore) buildDeleteAllAssetsDTO(tx *gorm.DB, data ...interface{
 	if len(data) != 1 {
 		return nil, errInvalidParams
 	}
-	teamID, ok := data[0].(string)
+	team, ok := data[0].(api.Team)
 	if !ok {
 		return nil, errInvalidParams
 	}
-	team, err := db.FindTeam(teamID)
-	if err != nil {
-		return nil, err
-	}
-
 	// Don't store unnecessary data
 	team.Assets = nil
 	team.UserTeam = nil
 	team.Groups = nil
 
-	return cdc.OpDeleteAllAssetsDTO{Team: *team}, nil
+	return cdc.OpDeleteAllAssetsDTO{Team: team}, nil
 }
 
 // buildFindingOverwriteDTO builds a FindingOverwrite action DTO for outbox.

--- a/pkg/api/store/team_test.go
+++ b/pkg/api/store/team_test.go
@@ -492,26 +492,6 @@ func TestStoreDeleteTeam(t *testing.T) {
 			if tt.verifyOutBox != nil {
 				tt.verifyOutBox()
 			}
-
-			// if err != nil {
-			// 	// Verify outbox data
-			// 	expCreatedAt, _ := time.Parse("2006-01-02 15:04:05", "2018-01-01 12:30:12")
-			// 	expUpdatedAt, _ := time.Parse("2006-01-02 15:04:05", "2018-01-01 12:30:12")
-			// 	deleteDTO := cdc.OpDeleteTeamDTO{
-			// 		Team: api.Team{
-			// 			ID:          "0ef82297-e7c7-4c46-a852-ae3ffbecc4bc",
-			// 			Name:        "Delete Team",
-			// 			Description: "Team to be deleted",
-			// 			CreatedAt:   &expCreatedAt,
-			// 			UpdatedAt:   &expUpdatedAt,
-			// 		},
-			// 	}
-			// 	expOutbox := expOutbox{
-			// 		action: opDeleteTeam,
-			// 		dto:    deleteDTO,
-			// 	}
-			// 	verifyOutbox(t, testStoreLocal, expOutbox, nil)
-			// }
 		})
 	}
 }

--- a/pkg/api/store/team_test.go
+++ b/pkg/api/store/team_test.go
@@ -5,6 +5,7 @@ Copyright 2021 Adevinta
 package store
 
 import (
+	"encoding/json"
 	"errors"
 	"log"
 	"testing"
@@ -368,21 +369,100 @@ func TestStoreUpdateTeam(t *testing.T) {
 }
 
 func TestStoreDeleteTeam(t *testing.T) {
-	testStoreLocal, err := testutil.PrepareDatabaseLocal("../../../testdata/fixtures", NewDB)
+	localStore, err := testutil.PrepareDatabaseLocal("../../../testdata/fixtures", NewDB)
 	if err != nil {
 		log.Fatal(err)
 	}
+	testStoreLocal := localStore.(vulcanitoStore)
 	defer testStoreLocal.Close()
+	expCreatedAt, _ := time.Parse("2006-01-02 15:04:05", "2017-01-01 12:30:12")
+	expUpdatedAt, _ := time.Parse("2006-01-02 15:04:05", "2017-01-01 12:30:12")
+	discoveryMergeTeamAssets := []api.Asset{}
+	var discoveryMergeTeamID = "a14c7c65-66ab-4676-bcf6-0dea9719f5c6"
+	err = testStoreLocal.Conn.
+		Preload("Team").
+		Preload("AssetType").
+		Preload("AssetAnnotations").
+		Where("team_id = ?", discoveryMergeTeamID).
+		Find(&discoveryMergeTeamAssets).Error
 
 	tests := []struct {
-		name    string
-		teamID  string
-		wantErr error
+		name         string
+		teamID       string
+		expOutbox    []expOutbox
+		verifyOutBox func()
+		wantErr      error
 	}{
 		{
-			name:    "HappyPath",
-			teamID:  "0ef82297-e7c7-4c46-a852-ae3ffbecc4bc",
-			wantErr: nil,
+			name:   "HappyPath",
+			teamID: discoveryMergeTeamID,
+			verifyOutBox: func() {
+				expDeletedAllAssets := expOutbox{
+					action: opDeleteTeam,
+					dto: cdc.OpDeleteTeamDTO{
+						Team: api.Team{
+							ID:          discoveryMergeTeamID,
+							Name:        "Foo Team",
+							Description: "Foo foo...",
+							Tag:         "team:foo-team",
+							CreatedAt:   &expCreatedAt,
+							UpdatedAt:   &expUpdatedAt,
+						},
+					},
+				}
+				var gotOutbox []cdc.Outbox = make([]cdc.Outbox, 0)
+				db := testStoreLocal
+				err := db.Conn.Raw(`
+					SELECT * FROM outbox
+					ORDER BY created_at DESC`,
+				).Scan(&gotOutbox).Error
+				if err != nil {
+					t.Fatalf("error verifying outbox: %v", err)
+				}
+				expOutboxLen := len(discoveryMergeTeamAssets) + 1
+				if len(gotOutbox) != expOutboxLen {
+					t.Fatalf("error verifying outbox, expected %d records got %d", expOutboxLen, len(gotOutbox))
+				}
+				ignoreFields := map[string][]string{}
+				// We expect the last operation to be the delete all asset operation.
+				diff := expDeletedAllAssets.Compare(gotOutbox[expOutboxLen-1], ignoreFields)
+				if diff != "" {
+					t.Fatalf("error verifying outbox, expected last operation != got last operation, diff:\n %s", diff)
+				}
+				gotOutbox = gotOutbox[:expOutboxLen-1]
+				for _, exp := range discoveryMergeTeamAssets {
+					var gotDTO *cdc.OpDeleteAssetDTO
+					for z, a := range gotOutbox {
+						if a.Operation != opDeleteAsset {
+							fmtStr := "error verifying outbox, expected record in position to have operation %d to be: %s but is: %s"
+							t.Fatalf(fmtStr, z, opDeleteAsset, a.Operation)
+						}
+						var dto cdc.OpDeleteAssetDTO
+						err := json.Unmarshal(a.DTO, &dto)
+						if err != nil {
+							fmtStr := "error verifying outbox unmarshaling data from got outbox record: %s"
+							t.Fatalf(fmtStr, string(a.DTO))
+						}
+						if dto.Asset.ID == exp.ID {
+							gotDTO = &dto
+							break
+						}
+					}
+					if gotDTO == nil {
+						fmtStr := "error verifying outbox expected asset %+v, not found in outbox"
+						t.Fatalf(fmtStr, exp)
+					}
+					if gotDTO.DeleteAllAssetsOp != true {
+						fmtStr := "error verifying outbox expected DeletedAllAssets to be true, but is false in: %+v"
+						t.Fatalf(fmtStr, *gotDTO)
+					}
+					ignoreFieldsAsset := cmpopts.IgnoreFields(api.Asset{}, baseModelFieldNames...)
+					diff := cmp.Diff(exp, gotDTO.Asset, ignoreFieldsAsset, ignoreFieldsTeam)
+					if diff != "" {
+						t.Fatalf("error verifying outbox, DTO's do not match.\nDiff:\n%v", diff)
+					}
+				}
+			},
 		},
 		{
 			name:    "TeamNotFound",
@@ -399,31 +479,39 @@ func TestStoreDeleteTeam(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			err := testStoreLocal.DeleteTeam(tt.teamID)
+			// We need to clean the outbox before each test.
+			err := testStoreLocal.Conn.Exec("DELETE FROM outbox").Error
+			if err != nil {
+				t.Fatalf("Error cleaning the outbox %+v", err)
+			}
+			err = testStoreLocal.DeleteTeam(tt.teamID)
 			diff := cmp.Diff(errToStr(tt.wantErr), errToStr(err))
 			if diff != "" {
 				t.Fatal(diff)
 			}
-
-			if err != nil {
-				// Verify outbox data
-				expCreatedAt, _ := time.Parse("2006-01-02 15:04:05", "2018-01-01 12:30:12")
-				expUpdatedAt, _ := time.Parse("2006-01-02 15:04:05", "2018-01-01 12:30:12")
-				deleteDTO := cdc.OpDeleteTeamDTO{
-					Team: api.Team{
-						ID:          "0ef82297-e7c7-4c46-a852-ae3ffbecc4bc",
-						Name:        "Delete Team",
-						Description: "Team to be deleted",
-						CreatedAt:   &expCreatedAt,
-						UpdatedAt:   &expUpdatedAt,
-					},
-				}
-				expOutbox := expOutbox{
-					action: opDeleteTeam,
-					dto:    deleteDTO,
-				}
-				verifyOutbox(t, testStoreLocal, expOutbox, nil)
+			if tt.verifyOutBox != nil {
+				tt.verifyOutBox()
 			}
+
+			// if err != nil {
+			// 	// Verify outbox data
+			// 	expCreatedAt, _ := time.Parse("2006-01-02 15:04:05", "2018-01-01 12:30:12")
+			// 	expUpdatedAt, _ := time.Parse("2006-01-02 15:04:05", "2018-01-01 12:30:12")
+			// 	deleteDTO := cdc.OpDeleteTeamDTO{
+			// 		Team: api.Team{
+			// 			ID:          "0ef82297-e7c7-4c46-a852-ae3ffbecc4bc",
+			// 			Name:        "Delete Team",
+			// 			Description: "Team to be deleted",
+			// 			CreatedAt:   &expCreatedAt,
+			// 			UpdatedAt:   &expUpdatedAt,
+			// 		},
+			// 	}
+			// 	expOutbox := expOutbox{
+			// 		action: opDeleteTeam,
+			// 		dto:    deleteDTO,
+			// 	}
+			// 	verifyOutbox(t, testStoreLocal, expOutbox, nil)
+			// }
 		})
 	}
 }


### PR DESCRIPTION
# Outbox CDC Assets refactor and race conditions fixing

This PR homogenizes the data sent to the outbox when any CRUD operation over
asset. Concretely, it ensures that every time an asset is added, updated or
deleted, all the data about the asset is enqueued in the outbox. It also
removes some race conditions that could case the data sent to the outbox to be
incorrect.
These modifications are a prerequisite for implementing event sourcing over an
event bus for the vulcan assets.

Notice that this PR is based on [this](https://github.com/adevinta/vulcan-api/pull/59) other PR, so even though is ready to be reviewed, it will need to be rebased to master after that PR is merged.

Bellow you can find the list of all the methods that perform CRUD operations
over assets, and then, for each method a high level description of the
modifications this PR made in each of them.

## Methods for CRUD operations over assets

1. createAsset(tx, asset)

2. updateAssetTX(tx, asset)

3. deleteAssetTX(tx *gorm.DB, asset api.Asset)

4. deleteAssetsUnsafeTX(tx, mergeOps.TeamID, mergeOps.Del)

5. DeleteAllAssets(teamID string)

6. DeleteTeam(teamID string)

### createAsset(tx, asset)

Sends to outbox using the method ``buildCreateAssetDTO(tx *gorm.DB, data ...interface{})``
including annotations

The data sent to the outbox its gathered using a SELECT inside the same
transaction of the INSERT, as the INSERT operation holds a lock in the entire
table until de transaction is committed, there are no race conditions here

#### Things to modify

None

### updateAssetTX(tx, asset)

Sends to outbox using the method ``buildUpdateAssetDTO(tx *gorm.DB, data ...interface{})``

#### Things to modify

1. Only pushes to outbox if the identifier of the asset changes

2. The data pushed to outbox could contain outdated old asset info

3. I doesn't send the annotations of the new asset to the outbox

Changes to make:

1. Sends modifications always.
2. Select for update ``oldAsset``
3. Query annotations (and lock them for update) before modifications and after modifications.

### deleteAssetTX(tx *gorm.DB, asset api.Asset)

Sends to outbox using the method ``buildDeleteAssetDTO(tx *gorm.DB, data ...interface{})``

Things to modify

1. Fix the race condition caused by using a SELECT to get the data about the
   asset to be deleted.

2. For sake of completeness send also the annotations.

### deleteAssetsUnsafeTX(tx, mergeOps.TeamID, mergeOps.Del)

Sends to outbox using the method ``buildDeleteAssetDTO(tx *gorm.DB, data ...interface{})``

Things to modify

1. Get and lock all the annotations of the assets to be deleted.

2. Return the data of the assets deleted to avoid sending possible stale data
   to the outbox.

3. Added tests for the method to test the delete assets data is properly
   populated to the outbox.

### DeleteAllAssets(teamID string)

Things to modify

1. The data pushed to the outbox is only the teamID that the deleted assets
belong to. We need to push also all the data related to the assets deleted. By
now we are modifying the function ``buildDeleteAssetDTO`` to receive one more
param indicating that the those deleted assets don't need to be processed by
now (We will process them in the future when we send the assets to the event
bus).

2. Also reduce (don't completely remove) the chances of getting the wrong data
about a team in the method ``buildDeleteAllAssetsDTO``` by sending the data about
the team instead of issuing a query to get that data.

### DeleteTeam(teamID string)

Things to modify

1. Lock for update the team at the beginning of the method to avoid race conditions.

2. We need to send to the outbox as many all the data related to the assets
deleted, apart from the delete team data operation that we are sending right
now.