### PR TITLE
Push new metrics for the discovery endpoint

### DIFF
--- a/pkg/api/service/assets.go
+++ b/pkg/api/service/assets.go
@@ -311,7 +311,7 @@ func (s vulcanitoService) MergeDiscoveredAssets(ctx context.Context, teamID stri
 	return mergedAssets
 }
 
-// pushDicoveryMetrics pushes metrics related to the discovery process.
+// pushDiscoveryMetrics pushes metrics related to the discovery process.
 func (s vulcanitoService) pushDiscoveryMetrics(assets []api.Asset, mergeOps api.AssetMergeOperations) {
 
 	componentTag := "component:api"


### PR DESCRIPTION
Return detailed metrics around the asset creation for the /discovery endpoint. 

The idea is to return (asynchronously) the exact numbers of assets that during the processing were:

Created
Skipped (that is, didn't need any processing)
Updated
Purged
Dissociated
This requirement is needed to be able to keep historically track of the fluctuations of discovered assets over time.

This is something that is already implemented client-side in Redcon (code) but cannot be replicated with the current implementation of the /discovery endpoint. If Redcon were to use the /discovery pipeline, we would automatically lose these metrics and these insights.


This PR creates five new metrics and pushes them only when they are greater than zero.

The metrics created are the following:

* `vulcan.discovery.created.count`
* `vulcan.discovery.skipped.count`
* `vulcan.discovery.updated.count`
* `vulcan.discovery.purged.count`
* `vulcan.discovery.dissociated.count`

