### PR TITLE
Return non scannable assets in DisjoinAssetsInGroups

### DIFF
--- a/pkg/api/persistence.go
+++ b/pkg/api/persistence.go
@@ -71,7 +71,7 @@ type VulcanitoStore interface {
 	// FindGroupInfo returns the info of the specified group
 	// without loading the assets and teams associated to it.
 	FindGroupInfo(group Group) (*Group, error)
-	// DisjoinAssetsInGroups returns scanable assets belonging to a team that are in a given
+	// DisjoinAssetsInGroups returns assets belonging to a team that are in a given
 	// group but not in other groups.
 	DisjoinAssetsInGroups(teamID, inGroupID string, notInGroupIDs []string) ([]*Asset, error)
 

--- a/pkg/api/store/assets.go
+++ b/pkg/api/store/assets.go
@@ -810,7 +810,7 @@ func (db vulcanitoStore) DisjoinAssetsInGroups(teamID, inGroupID string, notInGr
 	assets := []*api.Asset{}
 	res := db.Conn.Raw(`SELECT a.* FROM assets a
 			JOIN asset_group ag ON ag.asset_id=a.id JOIN asset_types t ON t.id=a.asset_type_id
-			WHERE a.scannable=true AND a.team_id=? AND ag.group_id=?
+			WHERE a.team_id=? AND ag.group_id=?
 			AND NOT EXISTS(SELECT 1 FROM asset_group ag2 JOIN assets a2 ON ag2.asset_id=a2.id WHERE ag2.asset_id=a.id AND a2.team_id=a.team_id AND ag2.group_id in (?))`,
 		teamID, inGroupID, notInGroupIDs).Scan(&assets)
 	if res.RecordNotFound() {

--- a/pkg/api/store/assets_test.go
+++ b/pkg/api/store/assets_test.go
@@ -1374,6 +1374,17 @@ func Test_vulcanitoStore_DisjoinAssetsInGroups_Multiple(t *testing.T) {
 				"6c391632-89ea-4a99-9177-624f709351bb", // disjoin3.adevinta.com
 			},
 		},
+		{
+			name: "ReturnsGroupWithNonScannable",
+			args: args{
+				inGroupID:     "1c0f00c1-5229-4ab6-a81a-eda76ec916a3", // DisjoinC
+				notInGroupIDs: nil,
+				teamID:        "d335c30c-944f-4ab0-9b43-cffccdfbd848",
+			},
+			wantUUIDs: []string{
+				"5246d6ba-1cc8-4bbd-9581-635b9d2ec277", // disjoin5.adevinta.com
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1461,6 +1472,16 @@ func Test_vulcanitoStore_CountAssetsInGroups(t *testing.T) {
 				teamID: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", // Non-existent team
 			},
 			wantCount: 0,
+		},
+		{
+			name: "CountAssetsNonScannable",
+			args: args{
+				groupIDs: []string{
+					"1c0f00c1-5229-4ab6-a81a-eda76ec916a3", // DisjoinC
+				},
+				teamID: "d335c30c-944f-4ab0-9b43-cffccdfbd848",
+			},
+			wantCount: 1,
 		},
 	}
 

--- a/testdata/fixtures/asset_group.yml
+++ b/testdata/fixtures/asset_group.yml
@@ -45,6 +45,9 @@
 - asset_id: 6a521ca7-490e-4789-a716-c2baca750884 # disjoin4.adevinta.com
   group_id: 78ba0bb9-cce7-451d-8e17-ae6b3efbb788 # DisjoinB
 
+- asset_id: 5246d6ba-1cc8-4bbd-9581-635b9d2ec277 # disjoin5.adevinta.com
+  group_id: 1c0f00c1-5229-4ab6-a81a-eda76ec916a3 # DisjoinC
+
 # discovery merge tests
 - asset_id: 6ace4174-e704-4ea3-9c68-9096966a7e61 # default.vulcan.example.com
   group_id: dd4f7ee7-76de-4922-aeb3-1eade1233550 # Default

--- a/testdata/fixtures/assets.yml
+++ b/testdata/fixtures/assets.yml
@@ -109,6 +109,14 @@
   environmental_cvss: 5
   options: {}
 
+- id: 5246d6ba-1cc8-4bbd-9581-635b9d2ec277
+  team_id: d335c30c-944f-4ab0-9b43-cffccdfbd848
+  identifier: disjoin5.adevinta.com
+  asset_type_id: 1937b564-bbc4-47f6-9722-b4a8c8ac0595
+  scannable: false
+  environmental_cvss: 5
+  options: {}
+
 # discovery merge tests
 - id: 6ace4174-e704-4ea3-9c68-9096966a7e61
   team_id: ea686be5-be9b-473b-ab1b-621a4f575d51


### PR DESCRIPTION
## Problem
The endpoint (/team/{team_id}/assets) that retrieves the list of assets from a team does not return the correct list of groups when an asset is marked as non-scannable.

If the asset is marked as non-scannable, the global groups do not appear in the list of groups of the asset.

In addiction, the endpoint that retrieves a group's assets (/team/{team_id}/groups/{group_id}/assets) does not return non-scannables assets when the group is a global group.

## Solution
The endpoints now return scannable and non-scannable assets.

## Caution
Please, before merging this PR it's necessary to check with @julianvilas  in order to avoid any undesired effect on the services that use the affected endpoints.