### PR TITLE
Upgrade Flyway

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 dist: bionic
 env:
   global:
-    - FLYWAY_VERSION=9.1.4
+    - FLYWAY_VERSION=9.4.0
     - INPUT_BUILDARGS=FLYWAY_VERSION=$FLYWAY_VERSION
 go:
   - 1.19.x

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /flyway
 
 RUN apk add --no-cache --update openjdk8-jre-base bash gettext libc6-compat
 
-ARG FLYWAY_VERSION=9.1.4
+ARG FLYWAY_VERSION=9.4.0
 
 RUN wget https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/${FLYWAY_VERSION}/flyway-commandline-${FLYWAY_VERSION}.tar.gz \
     && tar -xzf flyway-commandline-${FLYWAY_VERSION}.tar.gz --strip 1 \


### PR DESCRIPTION
This PR upgrades Flyway to v9.4.0 in order to fix some associated vulnerabilities present in dependencies:
- org.apache.commons:commons-text:1.9
- com.fasterxml.jackson.core:jackson-databind:2.13.2.1