### PR TITLE
Fine tune Kafka implementation

### DIFF
--- a/pkg/asyncapi/kafka/client.go
+++ b/pkg/asyncapi/kafka/client.go
@@ -66,10 +66,8 @@ func (c *Client) Push(entity string, id string, payload []byte, metadata map[str
 	if !ok {
 		return ErrUndefinedEntity
 	}
-
 	delivered := make(chan kafka.Event)
 	defer close(delivered)
-
 	var headers []kafka.Header
 	for k, v := range metadata {
 		headers = append(headers, kafka.Header{
@@ -77,7 +75,6 @@ func (c *Client) Push(entity string, id string, payload []byte, metadata map[str
 			Value: v,
 		})
 	}
-
 	msg := kafka.Message{
 		TopicPartition: kafka.TopicPartition{
 			Topic:     &topic,
@@ -91,14 +88,7 @@ func (c *Client) Push(entity string, id string, payload []byte, metadata map[str
 	if err != nil {
 		return fmt.Errorf("error producing message: %w", err)
 	}
-
-	var e kafka.Event
-	select {
-	case <-time.After(maxDeliveryWait):
-		return fmt.Errorf("error time out waiting for mssg delivery confirmation")
-	case e = <-delivered:
-	}
-
+	e := <-delivered
 	m := e.(*kafka.Message)
 	if m.TopicPartition.Error != nil {
 		return fmt.Errorf("error delivering message: %w", m.TopicPartition.Error)

--- a/pkg/asyncapi/kafka/client.go
+++ b/pkg/asyncapi/kafka/client.go
@@ -7,6 +7,7 @@ package kafka
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 )
@@ -23,6 +24,8 @@ var (
 const (
 	kafkaSecurityProtocol = "sasl_ssl"
 	kafkaSaslMechanisms   = "SCRAM-SHA-256"
+
+	maxDeliveryWait = 30 * time.Second
 )
 
 // Client implements an EventStreamClient using Kafka as the event stream
@@ -63,8 +66,10 @@ func (c *Client) Push(entity string, id string, payload []byte, metadata map[str
 	if !ok {
 		return ErrUndefinedEntity
 	}
+
 	delivered := make(chan kafka.Event)
 	defer close(delivered)
+
 	var headers []kafka.Header
 	for k, v := range metadata {
 		headers = append(headers, kafka.Header{
@@ -72,6 +77,7 @@ func (c *Client) Push(entity string, id string, payload []byte, metadata map[str
 			Value: v,
 		})
 	}
+
 	msg := kafka.Message{
 		TopicPartition: kafka.TopicPartition{
 			Topic:     &topic,
@@ -85,7 +91,14 @@ func (c *Client) Push(entity string, id string, payload []byte, metadata map[str
 	if err != nil {
 		return fmt.Errorf("error producing message: %w", err)
 	}
-	e := <-delivered
+
+	var e kafka.Event
+	select {
+	case <-time.After(maxDeliveryWait):
+		return fmt.Errorf("error time out waiting for mssg delivery confirmation")
+	case e = <-delivered:
+	}
+
 	m := e.(*kafka.Message)
 	if m.TopicPartition.Error != nil {
 		return fmt.Errorf("error delivering message: %w", m.TopicPartition.Error)

--- a/pkg/testutil/kafka.go
+++ b/pkg/testutil/kafka.go
@@ -24,6 +24,7 @@ const KafkaTestBroker = "localhost:29092"
 // with the entities remapped to new topics created.
 func PrepareKafka(topics map[string]string) (map[string]string, error) {
 	// Generate a unique deterministic topic name for the caller of this function.
+	tRef := time.Now().Unix()
 	newTopics := map[string]string{}
 	var newTopicNames []string
 	for entity, topic := range topics {
@@ -31,7 +32,7 @@ func PrepareKafka(topics map[string]string) (map[string]string, error) {
 		callerName := strings.Replace(runtime.FuncForPC(pc).Name(), ".", "_", -1)
 		callerName = strings.Replace(callerName, "-", "_", -1)
 		parts := strings.Split(callerName, "/")
-		name := strings.ToLower(fmt.Sprintf("%s_%s_test", topic, parts[len(parts)-1]))
+		name := strings.ToLower(fmt.Sprintf("%s_%s_%d_test", topic, parts[len(parts)-1], tRef))
 		newTopics[entity] = name
 		newTopicNames = append(newTopicNames, name)
 	}
@@ -82,7 +83,7 @@ func createTopics(names []string) error {
 			break
 		}
 		if tResults.Error() == kafka.ErrTopicAlreadyExists {
-			continue
+			return fmt.Errorf("error creating topics: topic already exists")
 		}
 		return fmt.Errorf("error creating topics: %s", tResults.Error())
 	}


### PR DESCRIPTION
This PR fine tunes a couple of minor points in regards of the Kafka implementation:

- Kafka client push: Avoids the client to be able to block for ever waiting for a message delivery confirmation.
- Kafka test utils:
  - Improves randomization of topic names generation in order to avoid collisions during tests [due to non atomic create/delete topics methods]
  - Fixes infinite loop when trying to create a topic which already exists. Returns error instead.