### PR TITLE
Malformed asset identifier makes outbox CDC to stop processing

### DIFF
--- a/pkg/api/asset.go
+++ b/pkg/api/asset.go
@@ -7,6 +7,7 @@ package api
 import (
 	"database/sql/driver"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -43,6 +44,15 @@ type Asset struct {
 	ClassifiedAt      *time.Time         `json:"classified_at"`
 }
 
+func validateAWSARN(arn string) bool {
+	// This is a regular expression that matches AWS ARNs.
+	arnRegex := regexp.MustCompile(`^arn:(aws|aws-cn|aws-us-gov):([a-z0-9-]+):([a-z\d-]*):([0-9]*):([a-zA-Z0-9_-]*)(//?[a-zA-Z0-9_-]+)*(//.*)?.*$`)
+
+	// Check if the ARN matches the regular expression.
+	return arnRegex.MatchString(arn)
+}
+
+// Validate checks if an asset is valid.
 func (a Asset) Validate() error {
 	err := validator.New().Struct(a)
 	if err != nil {
@@ -58,7 +68,7 @@ func (a Asset) Validate() error {
 			return errors.Validation("Identifier is not a valid Hostname")
 		}
 	case "AWSAccount":
-		if !types.IsAWSARN(a.Identifier) {
+		if !validateAWSARN(a.Identifier) || !types.IsAWSARN(a.Identifier) {
 			return errors.Validation("Identifier is not a valid AWSAccount")
 		}
 	case "DockerImage":

--- a/pkg/api/asset.go
+++ b/pkg/api/asset.go
@@ -46,8 +46,11 @@ type Asset struct {
 
 func validateAWSARN(arn string) bool {
 	// This is a regular expression that matches AWS ARNs.
-	arnRegex := regexp.MustCompile(`^arn:(aws|aws-cn|aws-us-gov):([a-z0-9-]+):([a-z\d-]*):([0-9]*):([a-zA-Z0-9_-]*)(//?[a-zA-Z0-9_-]+)*(//.*)?.*$`)
-
+	arnRegex, err := regexp.Compile(`^arn:(aws|aws-cn|aws-us-gov):([a-z0-9-]+):([a-z\d-]*):([0-9]*):([a-zA-Z0-9_-]*)(//?[a-zA-Z0-9_-]+)*(//.*)?.*$`)
+	if err != nil {
+		// Return false if there has been an error compiling the string.
+		return false
+	}
 	// Check if the ARN matches the regular expression.
 	return arnRegex.MatchString(arn)
 }

--- a/pkg/api/service/assets_test.go
+++ b/pkg/api/service/assets_test.go
@@ -539,6 +539,52 @@ func TestVulcanitoService_CreateAssets(t *testing.T) {
 			},
 			wantErr: nil,
 		},
+		{
+			name: "Malformed ARN format",
+			srvBuilder: VulcanitoServiceTestArgs{
+				BuildSrv: buildUserVulcanitoSrvWithAWSMock(cgCatalogueMock{
+					accounts: map[string]string{
+						"123456789012": "alias1",
+					},
+				}),
+			},
+			assets: []api.Asset{
+				api.Asset{
+					TeamID:     "a14c7c65-66ab-4676-bcf6-0dea9719f5c6",
+					Identifier: "arn:aws:iam:: 123456789011:root",
+					AssetType:  &api.AssetType{Name: "AWSAccount"},
+					Options:    common.String(""),
+					Scannable:  common.Bool(true),
+					ROLFP:      &api.ROLFP{IsEmpty: true},
+				},
+			},
+			groups:  []api.Group{},
+			want:    []api.Asset(nil),
+			wantErr: errors.New("Identifier is not a valid AWSAccount"),
+		},
+		{
+			name: "Malformed ARN format asset type not provided",
+			srvBuilder: VulcanitoServiceTestArgs{
+				BuildSrv: buildUserVulcanitoSrvWithAWSMock(cgCatalogueMock{
+					accounts: map[string]string{
+						"123456789012": "alias1",
+					},
+				}),
+			},
+			assets: []api.Asset{
+				api.Asset{
+					TeamID:     "a14c7c65-66ab-4676-bcf6-0dea9719f5c6",
+					Identifier: "arn:aws:iam:: 123456789011:root",
+					AssetType:  &api.AssetType{Name: ""},
+					Options:    common.String(""),
+					Scannable:  common.Bool(true),
+					ROLFP:      &api.ROLFP{IsEmpty: true},
+				},
+			},
+			groups:  []api.Group{},
+			want:    []api.Asset(nil),
+			wantErr: errors.New("[asset][arn:aws:iam:: 123456789011:root][] Identifier is not a valid AWSAccount"),
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/vulnerabilitydb/vulnerabilitydb.go
+++ b/pkg/vulnerabilitydb/vulnerabilitydb.go
@@ -532,7 +532,7 @@ func isStatusOk(status int) bool {
 func buildFilter(filters map[string]string) string {
 	filterParts := []string{}
 	for key, value := range filters {
-		part := fmt.Sprintf("%s=%s", key, value)
+		part := fmt.Sprintf("%s=%s", key, url.QueryEscape(value))
 		filterParts = append(filterParts, part)
 	}
 	return strings.Join(filterParts, "&")


### PR DESCRIPTION
A user can add an asset through the UI (and hence through the API) with a malformed identifier, for example, an AWS account ARN with a space in the middle:

`arn:aws:iam:: 012345678900:root`

This causes the outbox CDC to stop working as the subsequent request to the vulnerabilitydb-api to propagate the action fails:
```
component=CDC error=\"<html><body><h1>400 Bad request</h1>\\nYour browser sent an invalid request.\\n</body></html>\\n\" id=93995f78-025e-413e-99d4-d047a4198bd7 action=DeleteAsset retries=20\n","stream":"stderr","time":"2023-05-03T09:05:32.744982511Z"
```

This PR adds two types of controls:
- The first one is a check to avoid creating assets with malformed identifiers
- The second one is to query escape the strings when we make requests to vulcandb.