### PR TITLE
Enable custom assettypes

### DIFF
--- a/pkg/api/asset.go
+++ b/pkg/api/asset.go
@@ -105,8 +105,8 @@ func (a Asset) Validate() error {
 			return errors.Validation("Identifier is not a valid DomainName")
 		}
 	default:
-		// If none of the previous case match, force a validation error
-		return errors.Validation("Asset type not supported")
+		// If none of the previous case match, should be fine.
+		return nil
 	}
 
 	return nil

--- a/pkg/api/endpoint/assets.go
+++ b/pkg/api/endpoint/assets.go
@@ -205,7 +205,8 @@ func makeMergeDiscoveredAssetsEndpoint(s api.VulcanitoService, logger kitlog.Log
 			if ar.Identifier == "" || ar.Type == "" {
 				return nil, errors.Validation("Asset identifier and type are required for all the assets")
 			}
-			if !api.ValidAssetType(ar.Type) {
+
+			if _, err := s.GetAssetType(ctx, ar.Type); err != nil {
 				return nil, errors.Validation(fmt.Errorf("Invalid asset type (%s) for asset (%v)", ar.Type, ar.Identifier))
 			}
 


### PR DESCRIPTION
This pr allows the use of custom assettypes.

- The validation for a valid assettype now relies on the existence on the database.
- Do not fails In case of a non standard assetType (i.e. regexp).

The custom assetTypes should be created in the database.

See also https://github.com/adevinta/vulcan-ui/pull/60
