### PR TITLE
Remove dependabot limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,6 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  open-pull-requests-limit: 10
   labels:
     - "dependencies"
   commit-message:


### PR DESCRIPTION
This repository has many dependabot PRs not merged.
Because of the current dependabot configuration we are missiong our
own dependencies (i.e. github.com/adevinta/vulcan-scan-engine.

This pr removes this limitation.

