### PR TITLE
Add users command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
     - FLYWAY_VERSION=9.19.3
     - INPUT_BUILDARGS=FLYWAY_VERSION=$FLYWAY_VERSION
 go:
-  - 1.19.x
+  - 1.21.x
 services:
   - docker
 go_import_path: github.com/adevinta/vulcan-api

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright 2021 Adevinta
 
-FROM golang:1.20-alpine3.18 as builder
+FROM golang:1.21-alpine3.18 as builder
 # Required because the dependency
 # https://github.com/confluentinc/confluent-kafka-go requires the gcc compiler.
 RUN apk add gcc libc-dev

--- a/cmd/vulcan-cli/cmd/users.go
+++ b/cmd/vulcan-cli/cmd/users.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2023 Adevinta
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"slices"
+
+	"github.com/adevinta/vulcan-api/cmd/vulcan-cli/cli"
+	"github.com/spf13/cobra"
+)
+
+var users = &cobra.Command{
+	Use:   "users <output_file>",
+	Short: "Writes the list of the emails corresponding to all the users and recipients in Vulcan to the specified output file.",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runUsers(args[0], apiClient)
+	},
+}
+
+func init() {
+	users.Flags().BoolVarP(&force, "force", "f", false, "overwrites the output file if it exits")
+	rootCmd.AddCommand(users)
+}
+
+func runUsers(outputFile string, apiCLI *cli.CLI) error {
+	// Check for the existence of the file before performing the calls to
+	// the vulcan api to avoid the user to wait just to see the command fail.
+	exists, err := fileExists(outputFile)
+	if err != nil {
+		return err
+	}
+	if exists && !force {
+		return ErrOutputAlreadyExists
+	}
+	emails := map[string]struct{}{}
+	teams, err := apiCLI.Teams()
+	if err != nil {
+		return fmt.Errorf("error retrieving teams: %w", err)
+	}
+	for _, t := range teams {
+		members, err := apiCLI.Members(t.ID)
+		if err != nil {
+			return fmt.Errorf("error retrieving members of the team %s: %w", t.ID, err)
+		}
+		for _, m := range members {
+			emails[m.Email] = struct{}{}
+		}
+		recipients, err := apiCLI.Recipients(t.ID)
+		if err != nil {
+			return fmt.Errorf("error retrieving recipients of the team %s: %w", t.ID, err)
+		}
+		for _, r := range recipients {
+			emails[r.Email] = struct{}{}
+		}
+	}
+	var list []string
+	for email := range emails {
+		list = append(list, email)
+	}
+	// Sort the output so its easier to visually compare results between
+	// executions.
+	slices.Sort(list)
+	// We accept that if the output file was created after we checked for
+	// its existence above and now the file will be overwritten.
+	fs, err := os.OpenFile(outputFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	defer fs.Close()
+	for _, email := range list {
+		if _, err := fmt.Fprintln(fs, email); err != nil {
+			return fmt.Errorf("error writing to stdout %w", err)
+		}
+	}
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/adevinta/vulcan-api
 
-go 1.19
+go 1.21
 
 require (
 	github.com/adevinta/errors v1.0.0


### PR DESCRIPTION
This PR does 2 things: 
* Bumps the version of go to 1.21
* Adds a new command to the `vulcan-cli` tool
    The new command `users` generates a file with the usernames of all the users in all the teams in Vulcan, both members and owners, and with the emails included in the recipients of each team. The generated file contains the list of unique users and emails, sorted  lexicographically.