### PR TITLE
Dockerfile build breaks on step 22 due to a missing slash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ COPY db/sql /app/sql/
 
 RUN mkdir -p /app/output
 
-COPY --link config.toml run.sh .
-COPY --from=builder --link /app/cmd/vulcan-api/vulcan-api .
+COPY --link config.toml run.sh ./
+COPY --from=builder --link /app/cmd/vulcan-api/vulcan-api ./
 
 CMD [ "./run.sh" ]


### PR DESCRIPTION
Error message when running build.sh:

```
Step 22/24 : COPY --link config.toml run.sh .
When using COPY with more than one source file, the destination must be a directory and end with a /
```

Docker version:
```
$ docker --version
Docker version 24.0.5, build 24.0.5-0ubuntu1
```