### PR TITLE
Allow configure tracker for all the teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Those are the variables you have to setup:
 |PERSISTENCE_HOST||persistence.vulcan.example.com|
 |VULNERABILITYDB_URL||http://localhost:8083|
 |VULCANTRACKER_URL|Leave the url empty if you don't want to configure the vulcan-tracker component|http://localhost:8085|
+|VULCANTRACKER_TEAMS|comma separated list of team ids that has tracker integration,`*` for all|ba2f2a9b-1ea8-4a28-9519-eab4ed290866|
 |VULCAN_UI_URL|Vulcan UI base URL for Digest report link|http://localhost:1234|
 |GPC_${i}_NAME|Specify the name of the global policy that the ${i} ALLOW/BLOCK list will apply. Rquired if any ALLOW/BLOCK list is specified.|web-scanning-global|
 |GPC_${i}_ALLOWED_ASSETTYPES|Specify an array of allowed assettypes for the specified global policy. Optional.|[]|

--- a/pkg/api/service/tickets.go
+++ b/pkg/api/service/tickets.go
@@ -6,6 +6,7 @@ package service
 
 import (
 	"context"
+
 	"github.com/adevinta/vulcan-api/pkg/api"
 )
 
@@ -29,7 +30,7 @@ func (s vulcanitoService) IsATeamOnboardedInVulcanTracker(ctx context.Context, t
 		return false
 	}
 	for _, team := range onboardedTeams {
-		if team == teamID {
+		if team == teamID || team == "*" {
 			return true
 		}
 	}

--- a/pkg/api/service/tickets.go
+++ b/pkg/api/service/tickets.go
@@ -6,19 +6,28 @@ package service
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/adevinta/vulcan-api/pkg/api"
 )
 
+func isTrackerAllowed(ctx context.Context) bool {
+	user, err := api.UserFromContext(ctx)
+	return err == nil && (user.Admin != nil && *user.Admin) || (user.Observer != nil && *user.Observer)
+}
+
 // CreateFindingTicket requests the creation of a ticket in the ticket tracker
 // with the values stored in the argument ticket.
 func (s vulcanitoService) CreateFindingTicket(ctx context.Context, ticket api.FindingTicketCreate) (*api.Ticket, error) {
+	if !isTrackerAllowed(ctx) {
+		return nil, fmt.Errorf("unauthorized to create a ticket")
+	}
 	return s.vulcantrackerClient.CreateTicket(ctx, ticket)
 }
 
 // GetFindingTicket makes a request to vulcan tracker to find a ticket for a team.
 func (s vulcanitoService) GetFindingTicket(ctx context.Context, findingID, teamID string) (*api.Ticket, error) {
-	if s.vulcantrackerClient == nil {
+	if s.vulcantrackerClient == nil || !isTrackerAllowed(ctx) {
 		return nil, nil
 	}
 	return s.vulcantrackerClient.GetFindingTicket(ctx, findingID, teamID)
@@ -27,6 +36,9 @@ func (s vulcanitoService) GetFindingTicket(ctx context.Context, findingID, teamI
 // IsATeamOnboardedInVulcanTracker return if a team is onboarded in vulcan tracker.
 func (s vulcanitoService) IsATeamOnboardedInVulcanTracker(ctx context.Context, teamID string, onboardedTeams []string) bool {
 	if s.vulcantrackerClient == nil {
+		return false
+	}
+	if !isTrackerAllowed(ctx) {
 		return false
 	}
 	for _, team := range onboardedTeams {

--- a/pkg/api/service/tickets_test.go
+++ b/pkg/api/service/tickets_test.go
@@ -8,22 +8,90 @@ import (
 	"context"
 	"testing"
 
+	"github.com/adevinta/vulcan-api/pkg/api"
+	"github.com/adevinta/vulcan-api/pkg/common"
 	"github.com/adevinta/vulcan-api/pkg/tickets"
 )
 
 func TestVulcanitoService_OnboardedTeam(t *testing.T) {
-	srv := vulcanitoService{}
-	if srv.IsATeamOnboardedInVulcanTracker(context.TODO(), "whatever-team", []string{"whatever-team"}) {
-		t.Fatal("vulcanitoService.IsATeamOnboardedInVulcanTracker() no-client")
+	srv := vulcanitoService{
+		vulcantrackerClient: tickets.NewClient(nil, "", true),
 	}
-	srv.vulcantrackerClient = tickets.NewClient(nil, "", true)
-	if !srv.IsATeamOnboardedInVulcanTracker(context.TODO(), "whatever-team", []string{"*"}) {
-		t.Fatal("vulcanitoService.IsATeamOnboardedInVulcanTracker() all")
+	ctx := context.Background()
+	ctxAdmin := api.ContextWithUser(ctx, api.User{Admin: common.Bool(true)})
+	ctxObserver := api.ContextWithUser(ctx, api.User{Observer: common.Bool(true)})
+
+	tests := []struct {
+		name           string
+		srv            vulcanitoService
+		context        context.Context
+		onboardedTeams []string
+		teamID         string
+		want           bool
+	}{
+		{
+			name:           "OnboardedAllTeamsNoClient",
+			srv:            vulcanitoService{},
+			context:        ctxAdmin,
+			onboardedTeams: []string{"whatever-team", "*"},
+			teamID:         "other-team",
+			want:           false,
+		},
+		{
+			name:           "HappyPath-admin",
+			srv:            srv,
+			context:        ctxAdmin,
+			onboardedTeams: []string{"whatever-team"},
+			teamID:         "whatever-team",
+			want:           true,
+		},
+		{
+			name:           "HappyPath-observer",
+			srv:            srv,
+			context:        ctxObserver,
+			onboardedTeams: []string{"whatever-team"},
+			teamID:         "whatever-team",
+			want:           true,
+		},
+		{
+			name:           "HappyPath-no-auth",
+			srv:            srv,
+			context:        ctx,
+			onboardedTeams: []string{"whatever-team"},
+			teamID:         "whatever-team",
+			want:           false,
+		},
+		{
+			name:           "NoOnboardedTeam",
+			srv:            srv,
+			context:        ctxAdmin,
+			onboardedTeams: []string{"whatever-team"},
+			teamID:         "other-team",
+			want:           false,
+		},
+		{
+			name:           "OnboardedAllTeams",
+			srv:            srv,
+			context:        ctxAdmin,
+			onboardedTeams: []string{"whatever-team", "*"},
+			teamID:         "other-team",
+			want:           true,
+		},
+		{
+			name:           "NoOnboardedAllTeams",
+			srv:            srv,
+			context:        ctxAdmin,
+			onboardedTeams: []string{},
+			teamID:         "other-team",
+			want:           false,
+		},
 	}
-	if !srv.IsATeamOnboardedInVulcanTracker(context.TODO(), "whatever-team", []string{"whatever-team"}) {
-		t.Fatal("vulcanitoService.IsATeamOnboardedInVulcanTracker() explicit")
-	}
-	if srv.IsATeamOnboardedInVulcanTracker(context.TODO(), "whatever-team", []string{"other"}) {
-		t.Fatal("vulcanitoService.IsATeamOnboardedInVulcanTracker() not")
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.srv.IsATeamOnboardedInVulcanTracker(tt.context, tt.teamID, tt.onboardedTeams) != tt.want {
+				t.Fatal("error")
+			}
+		})
 	}
 }

--- a/pkg/api/service/tickets_test.go
+++ b/pkg/api/service/tickets_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2024 Adevinta
+*/
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/adevinta/vulcan-api/pkg/tickets"
+)
+
+func TestVulcanitoService_OnboardedTeam(t *testing.T) {
+	srv := vulcanitoService{}
+	if srv.IsATeamOnboardedInVulcanTracker(context.TODO(), "whatever-team", []string{"whatever-team"}) {
+		t.Fatal("vulcanitoService.IsATeamOnboardedInVulcanTracker() no-client")
+	}
+	srv.vulcantrackerClient = tickets.NewClient(nil, "", true)
+	if !srv.IsATeamOnboardedInVulcanTracker(context.TODO(), "whatever-team", []string{"*"}) {
+		t.Fatal("vulcanitoService.IsATeamOnboardedInVulcanTracker() all")
+	}
+	if !srv.IsATeamOnboardedInVulcanTracker(context.TODO(), "whatever-team", []string{"whatever-team"}) {
+		t.Fatal("vulcanitoService.IsATeamOnboardedInVulcanTracker() explicit")
+	}
+	if srv.IsATeamOnboardedInVulcanTracker(context.TODO(), "whatever-team", []string{"other"}) {
+		t.Fatal("vulcanitoService.IsATeamOnboardedInVulcanTracker() not")
+	}
+}


### PR DESCRIPTION
- Allow to setup `*` for onboarded_teams to activate tracker for all the teams.
- Only for admins or observers